### PR TITLE
Extend `RegionDetection/Set` and implement NMS

### DIFF
--- a/tree_detection_framework/detection/region_detections.py
+++ b/tree_detection_framework/detection/region_detections.py
@@ -319,8 +319,9 @@ class RegionDetectionsSet:
         concatenated_geodataframes = pd.concat(detection_geodataframes)
 
         ## Merge_bounds
-        # get the bounds from each region
-        # Convert to a single shapely object as expected
+        # Get the merged bounds
+        merged_bounds = self.get_bounds(CRS=CRS)
+        # Convert to a single shapely object
         merged_bounds_shapely = merged_bounds.geometry[0]
 
         # Use the geometry column of the concatenated dataframes

--- a/tree_detection_framework/detection/region_detections.py
+++ b/tree_detection_framework/detection/region_detections.py
@@ -373,9 +373,9 @@ class RegionDetectionsSet:
     def get_bounds(self, CRS: Optional[pyproj.CRS] = None) -> gpd.GeoSeries:
         region_bounds = [rd.get_bounds(CRS=CRS) for rd in self.region_detections]
         # Create a geodataframe out of these region bounds
-        all_region_bounds = gpd.GeoDataFrame(pd.concat(region_bounds), crs=CRS)
+        all_region_bounds = gpd.GeoSeries(pd.concat(region_bounds), crs=CRS)
         # Compute the union of all bounds
-        merged_bounds = all_region_bounds.geometry.union_all()
+        merged_bounds = gpd.GeoSeries([all_region_bounds.geometry.union_all()], crs=CRS)
 
         return merged_bounds
 

--- a/tree_detection_framework/detection/region_detections.py
+++ b/tree_detection_framework/detection/region_detections.py
@@ -437,6 +437,27 @@ class RegionDetectionsSet:
 
         return merged_bounds
 
+    def disjoint_bounds(self) -> bool:
+        """Determine whether the bounds of the sub-regions are disjoint
+
+        Returns:
+            bool: Are they disjoint
+        """
+        # Get the bounds for each individual region
+        bounds = self.get_bounds(union_bounds=False)
+        # Get the union of all bounds
+        union_bounds = bounds.union_all()
+
+        # Find the sum of areas for each region
+        sum_individual_areas = bounds.area.sum()
+        # And the area of the union
+        union_area = union_bounds.area
+
+        # If the two areas are the same (down to numeric errors) then there are no overlaps
+        disjoint = np.allclose(sum_individual_areas, union_area)
+
+        return disjoint
+
     def save(
         self,
         save_path: PATH_TYPE,

--- a/tree_detection_framework/detection/region_detections.py
+++ b/tree_detection_framework/detection/region_detections.py
@@ -374,8 +374,13 @@ class RegionDetectionsSet:
         ]
         return list_of_region_data_frames
 
-    def get_bounds(self):
-        raise NotImplementedError()
+    def get_bounds(self, CRS: Optional[pyproj.CRS] = None):
+        # TODO consider changing this so it doesn't call .merge. This reprojects the detections which
+        # isn't neccessary, but it's simple.
+        merged_region_detections = self.merge(CRS=CRS)
+        # Get the bounds from the merged RD. Note that it's already in the requested CRS
+        merged_bounds = merged_region_detections.get_bounds()
+        return merged_bounds
 
     def save(
         self,

--- a/tree_detection_framework/detection/region_detections.py
+++ b/tree_detection_framework/detection/region_detections.py
@@ -381,26 +381,23 @@ class RegionDetectionsSet:
         self,
         save_path: PATH_TYPE,
         CRS: Optional[pyproj.CRS] = None,
-        as_pixels: Optional[bool] = False,
         region_ID_key: Optional[str] = "region_ID",
     ):
         """
-        Save the data to a geospatial file by calling get_data_frame and then saving to the specified
-        file. The containing folder is created if it doesn't exist.
+        Save the data to a geospatial file by calling get_data_frame with merge=True and then saving
+        to the specified file. The containing folder is created if it doesn't exist.
 
         Args:
             save_path (PATH_TYPE):
                File to save the data to. The containing folder will be created if it does not exist.
             CRS (Optional[pyproj.CRS], optional):
                 See get_data_frame.
-            as_pixels (Optional[bool], optional):
-                See get_data_frame.
             region_ID_key (Optional[str], optional):
                 See get_data_frame.
         """
         # Get the concatenated dataframes
         concatenated_geodataframes = self.get_data_frame(
-            CRS=CRS, as_pixels=as_pixels, region_ID_key=region_ID_key
+            CRS=CRS, region_ID_key=region_ID_key, merge=True
         )
 
         # Ensure that the folder to save them to exists

--- a/tree_detection_framework/detection/region_detections.py
+++ b/tree_detection_framework/detection/region_detections.py
@@ -337,7 +337,7 @@ class RegionDetectionsSet:
         self,
         CRS: Optional[pyproj.CRS] = None,
         merge: bool = False,
-        merge_region_ID_key: str = "region_ID",
+        region_ID_key: str = "region_ID",
     ) -> gpd.GeoDataFrame | List[gpd.GeoDataFrame]:
         """Get the detections, optionally specifying a CRS
 
@@ -347,7 +347,7 @@ class RegionDetectionsSet:
                 be used. Defaults to None.
             merge (bool, optional):
                 If true, return one dataframe. Else, return a list of individual dataframes.
-            merged_region_ID_key (str, optional):
+            region_ID_key (str, optional):
                 Use this column to identify which region each detection came from. Defaults to
                 "region_ID"
 
@@ -358,7 +358,7 @@ class RegionDetectionsSet:
         """
         if merge:
             # Merge all of the detections into one RegionDetection
-            merged_detections = self.merge(region_ID_key=merge_region_ID_key, CRS=CRS)
+            merged_detections = self.merge(region_ID_key=region_ID_key, CRS=CRS)
             # get the dataframe. It is already in the requested CRS in the current implementation.
             data_frame = merged_detections.get_data_frame()
             return data_frame

--- a/tree_detection_framework/detection/region_detections.py
+++ b/tree_detection_framework/detection/region_detections.py
@@ -188,7 +188,7 @@ class RegionDetections:
         # information about the transform to pixel coordinates are currently lost.
         self.detections.to_file(save_path)
 
-    def get_detections(
+    def get_data_frame(
         self, CRS: Optional[pyproj.CRS] = None, as_pixels: Optional[bool] = False
     ) -> gpd.GeoDataFrame:
         """Get the detections, optionally specifying a CRS or pixel coordinates
@@ -276,36 +276,37 @@ class RegionDetectionsSet:
         """
         self.region_detections = region_detections
 
-    def get_detections(
+    def merge(
         self,
-        CRS: Optional[pyproj.CRS] = None,
-        as_pixels: Optional[bool] = False,
         region_ID_key: Optional[str] = "region_ID",
+        CRS: Optional[pyproj.CRS] = None,
     ):
         """Get the merged detections across all regions with an additional field specifying which region
-        the detection came from. Optionally specify a CRS or pixel coordinates for all detections.
+        the detection came from.
 
         Args:
-            CRS (Optional[pyproj.CRS], optional):
-                Requested CRS for the output detections. If un-set, the CRS of self.detections will
-                be used. Defaults to None.
-            as_pixels (Optional[bool], optional):
-                Whether to return the values in pixel coordinates. Defaults to False.
             region_ID_key (Optional[str], optional):
                 Create this column in the output dataframe identifying which region that data came
                 from using a zero-indexed integer. Defaults to "region_ID".
+            CRS (Optional[pyproj.CRS], optional):
+                Requested CRS for merged detections. If un-set, the CRS of the first region will
+                be used. Defaults to None.
 
         Returns:
             gpd.GeoDataFrame: Detections in the requested CRS or in pixel coordinates with a None .crs
         """
-        # TODO do error checking in the case where the CRS is set to None and as_pixels is False.
-        # Since the native CRS of each region will be returned, it might be worth checking they are
-        # all the same.
+        # Check that every region is geospatial
+        regions_CRS_values = [rd.detections.crs for rd in self.region_detections]
+        if None in regions_CRS_values:
+            raise ValueError("Merging requires every region to have a CRS")
+
+        # If no CRS is provided default to the CRS of the first region
+        if CRS is None:
+            CRS = regions_CRS_values[0]
 
         # Get the detections from each region detection object as geodataframes
         detection_geodataframes = [
-            rd.get_detections(CRS=CRS, as_pixels=as_pixels)
-            for rd in self.region_detections
+            rd.get_data_frame(CRS=CRS) for rd in self.region_detections
         ]
 
         # Add a column to each geodataframe identifying which region detection object it came from
@@ -315,10 +316,66 @@ class RegionDetectionsSet:
             gdf[region_ID_key] = ID
 
         # Concatenate the geodataframes together
-        # TODO this could be a good place to check the CRS and ensure that all of them are equal
         concatenated_geodataframes = pd.concat(detection_geodataframes)
 
-        return concatenated_geodataframes
+        ## Merge_bounds
+        # get the bounds from each region
+        region_bounds = [rd.get_bounds(CRS=CRS) for rd in self.region_detections]
+        # Create a geodataframe out of these region bounds
+        all_region_bounds = gpd.GeoDataFrame(pd.concat(region_bounds), crs=CRS)
+        # Compute the union of all bounds
+        merged_bounds = all_region_bounds.geometry.union_all()
+        # Convert to a single shapely object as expected
+        merged_bounds_shapely = merged_bounds.geometry[0]
+
+        # Use the geometry column of the concatenated dataframes
+        merged_region_detections = RegionDetections(
+            detection_geometries="geometry",
+            data=concatenated_geodataframes,
+            input_in_pixels=False,
+            geospatial_prediction_bounds=merged_bounds_shapely,
+        )
+
+        return merged_region_detections
+
+    def get_data_frame(
+        self,
+        CRS: Optional[pyproj.CRS] = None,
+        merge: bool = False,
+        merge_region_ID_key: str = "region_ID",
+    ) -> gpd.GeoDataFrame | List[gpd.GeoDataFrame]:
+        """Get the detections, optionally specifying a CRS
+
+        Args:
+            CRS (Optional[pyproj.CRS], optional):
+                Requested CRS for the output detections. If un-set, the CRS of self.detections will
+                be used. Defaults to None.
+            merge (bool, optional):
+                If true, return one dataframe. Else, return a list of individual dataframes.
+            merged_region_ID_key (str, optional):
+                Use this column to identify which region each detection came from. Defaults to
+                "region_ID"
+
+        Returns:
+            gpd.GeoDataFrame | List[gpd.GeoDataFrame]:
+                If merge=True, then one dataframe with an addtional column specifying which region each
+                detection came from. If merge=False, then a list of dataframes for each region.
+        """
+        if merge:
+            # Merge all of the detections into one RegionDetection
+            merged_detections = self.merge(region_ID_key=merge_region_ID_key, CRS=CRS)
+            # get the dataframe. It is already in the requested CRS in the current implementation.
+            data_frame = merged_detections.get_data_frame()
+            return data_frame
+
+        # Get a list of dataframes from each region
+        list_of_region_data_frames = [
+            rd.get_data_frame(CRS=CRS) for rd in self.region_detections
+        ]
+        return list_of_region_data_frames
+
+    def get_bounds(self):
+        raise NotImplementedError()
 
     def save(
         self,
@@ -328,21 +385,21 @@ class RegionDetectionsSet:
         region_ID_key: Optional[str] = "region_ID",
     ):
         """
-        Save the data to a geospatial file by calling get_detections and then saving to the specified
+        Save the data to a geospatial file by calling get_data_frame and then saving to the specified
         file. The containing folder is created if it doesn't exist.
 
         Args:
             save_path (PATH_TYPE):
                File to save the data to. The containing folder will be created if it does not exist.
             CRS (Optional[pyproj.CRS], optional):
-                See get_detections.
+                See get_data_frame.
             as_pixels (Optional[bool], optional):
-                See get_detections.
+                See get_data_frame.
             region_ID_key (Optional[str], optional):
-                See get_detections.
+                See get_data_frame.
         """
         # Get the concatenated dataframes
-        concatenated_geodataframes = self.get_detections(
+        concatenated_geodataframes = self.get_data_frame(
             CRS=CRS, as_pixels=as_pixels, region_ID_key=region_ID_key
         )
 

--- a/tree_detection_framework/detection/region_detections.py
+++ b/tree_detection_framework/detection/region_detections.py
@@ -156,7 +156,7 @@ class RegionDetections:
         )
 
     def subset_detections(self, detection_indices) -> "RegionDetections":
-        """Return a new Reg
+        """Return a new RegionDetections object with only the detections indicated by the indices
 
         Args:
             detection_indices:

--- a/tree_detection_framework/detection/region_detections.py
+++ b/tree_detection_framework/detection/region_detections.py
@@ -328,6 +328,7 @@ class RegionDetectionsSet:
         merged_region_detections = RegionDetections(
             detection_geometries="geometry",
             data=concatenated_geodataframes,
+            CRS=CRS,
             input_in_pixels=False,
             geospatial_prediction_bounds=merged_bounds_shapely,
         )

--- a/tree_detection_framework/postprocessing/postprocessing.py
+++ b/tree_detection_framework/postprocessing/postprocessing.py
@@ -69,7 +69,7 @@ def multi_region_NMS(
     # Determine whether to run NMS individually on each region.
     if run_per_region_NMS:
         # Run NMS on each sub-region and then wrap this in a region detection set
-        region_detection_set_NMS_suppressed = RegionDetectionsSet(
+        detections = RegionDetectionsSet(
             [
                 single_region_NMS(
                     region_detections,
@@ -79,8 +79,6 @@ def multi_region_NMS(
                 for region_detections in detections.region_detections
             ]
         )
-        # Merge all the detections into one RegionDetections
-        detections = region_detection_set_NMS_suppressed.merge()
 
     # Merge the detections into a single RegionDetections
     merged_detections = detections.merge()
@@ -88,7 +86,9 @@ def multi_region_NMS(
     # If the bounds of the individual regions were disjoint, then no NMS needs to be applied across
     # the different regions
     if detections.disjoint_bounds():
+        print("Bounds are disjoint, skipping across-region NMS")
         return merged_detections
+    print("Bound have overlap, running across-region NMS")
 
     # Run NMS on this merged RegionDetections
     NMS_suppressed_merged_detections = single_region_NMS(

--- a/tree_detection_framework/postprocessing/postprocessing.py
+++ b/tree_detection_framework/postprocessing/postprocessing.py
@@ -28,7 +28,7 @@ def single_region_NMS(
             NMS-suppressed set of detections
     """
     # Extract the geodataframe for the detections
-    detections_df = detections.get_detections()
+    detections_df = detections.get_data_frame()
 
     # Get the axis-aligned bounds of each shape
     boxes = detections_df.bounds.to_numpy()

--- a/tree_detection_framework/postprocessing/postprocessing.py
+++ b/tree_detection_framework/postprocessing/postprocessing.py
@@ -1,20 +1,46 @@
+from typing import Optional
+
+from lsnms import nms
+
 from tree_detection_framework.detection.region_detections import (
     RegionDetections,
     RegionDetectionsSet,
 )
 
 
-def single_region_NMS(detections: RegionDetections) -> RegionDetections:
+def single_region_NMS(
+    detections: RegionDetections,
+    iou_theshold: float = 0.5,
+    confidence_column: str = "score",
+) -> RegionDetections:
     """Run non-max suppresion on predictions from a single region.
 
     Args:
-        detections (RegionDetections): Detections from a single region to run NMS on.
+        detections (RegionDetections):
+            Detections from a single region to run NMS on.
+        iou_threshold (float, optional):
+            What intersection over union value to consider an overlapping detection. Defaults to 0.5.
+        confidence_column (str, optional):
+            Which column in the dataframe to use as a confidence for NMS. Defaults to "score"
 
     Returns:
         RegionDetections:
             NMS-suppressed set of detections
     """
-    raise NotImplementedError()
+    # Extract the geodataframe for the detections
+    detections_df = detections.get_detections()
+
+    # Get the axis-aligned bounds of each shape
+    boxes = detections_df.bounds.to_numpy()
+    # Extract the score
+    confidences = detections_df[confidence_column].to_numpy()
+
+    # Run NMS
+    keep = nms(boxes, confidences, iou_threshold=iou_theshold)
+    # Extract the detections that were kept
+    subset_region_detections = detections.subset_detections(keep)
+
+    return subset_region_detections
 
 
 def multi_region_NMS(detections: RegionDetectionsSet) -> RegionDetections:

--- a/tree_detection_framework/postprocessing/postprocessing.py
+++ b/tree_detection_framework/postprocessing/postprocessing.py
@@ -80,10 +80,16 @@ def multi_region_NMS(
             ]
         )
         # Merge all the detections into one RegionDetections
-        merged_detections = region_detection_set_NMS_suppressed.merge()
-    else:
-        # Just merge the detections
-        merged_detections = detections.merge()
+        detections = region_detection_set_NMS_suppressed.merge()
+
+    # Merge the detections into a single RegionDetections
+    merged_detections = detections.merge()
+
+    # If the bounds of the individual regions were disjoint, then no NMS needs to be applied across
+    # the different regions
+    if detections.disjoint_bounds():
+        return merged_detections
+
     # Run NMS on this merged RegionDetections
     NMS_suppressed_merged_detections = single_region_NMS(
         merged_detections,


### PR DESCRIPTION
Most of this PR is making changes/extensions to the `RegionDetections` and `RegionDetectionsSet` classes to support streamlined NMS. 

- Add an explicit `merge` method to `RegionDetectionSet` to handle the logic of merging multiple regions together or returning a list of per-region detections.
- Rename `get_detections` to `get_data_frame`
- Add a method to get a copy of a `RegionDetections` with a subset of detections.
- Make the instantiation of a `RegionDetections` more flexible so inputs can be provided in geospatial coordinates but also have a transform to pixels associated.

Also I currently have un-used functionality to get the bounds of the predicted region in different CRS for both the `RegionDetections` and `RegionDetectionSet`. 