### PR TITLE
Add mask-to-shapely function and example

### DIFF
--- a/tree_detection_framework/utils/geometric.py
+++ b/tree_detection_framework/utils/geometric.py
@@ -1,4 +1,6 @@
 import numpy as np
+import shapely
+from contourpy import contour_generator
 
 
 def get_shapely_transform_from_matrix(matrix_transform: np.ndarray):
@@ -19,3 +21,37 @@ def get_shapely_transform_from_matrix(matrix_transform: np.ndarray):
         matrix_transform[1, 2],
     ]
     return shapely_transform
+
+
+def mask_to_shapely(mask: np.ndarray) -> shapely.MultiPolygon:
+    """Convert a binary mask to a shapely polygon representing the positive regions
+
+    Args:
+        mask (np.ndarary):
+            A (n, m) array where positive values are > 0.5 and negative values are < 0.5
+
+    Returns:
+        shapely.MultiPolygon:
+            A multipolygon representing the positive regions. Holes and multiple disconnected
+            componets are properly handled.
+    """
+    # This generally follows the example here:
+    # https://contourpy.readthedocs.io/en/v1.3.0/user_guide/external/shapely.html#filled-contours-to-shapely
+
+    # Extract the contours and create a filled contour for the regions above 0.5
+    filled = contour_generator(z=mask, fill_type="ChunkCombinedOffsetOffset").filled(
+        0.5, np.inf
+    )
+
+    # Create a polygon for each of the disconected regions, called chunks in contourpy
+    # This iterates over the elements in three lists, the points, offsets, and outer offsets
+    chunk_polygons = [
+        shapely.from_ragged_array(
+            shapely.GeometryType.POLYGON, points, (offsets, outer_offsets)
+        )
+        for points, offsets, outer_offsets in zip(*filled)
+    ]
+    # Union these regions to get a single multipolygon
+    multipolygon = shapely.unary_union(chunk_polygons)
+
+    return multipolygon

--- a/tree_detection_framework/utils/geometric.py
+++ b/tree_detection_framework/utils/geometric.py
@@ -33,7 +33,7 @@ def mask_to_shapely(mask: np.ndarray) -> shapely.MultiPolygon:
     Returns:
         shapely.MultiPolygon:
             A multipolygon representing the positive regions. Holes and multiple disconnected
-            componets are properly handled.
+            components are properly handled.
     """
     # This generally follows the example here:
     # https://contourpy.readthedocs.io/en/v1.3.0/user_guide/external/shapely.html#filled-contours-to-shapely
@@ -43,7 +43,7 @@ def mask_to_shapely(mask: np.ndarray) -> shapely.MultiPolygon:
         0.5, np.inf
     )
 
-    # Create a polygon for each of the disconected regions, called chunks in contourpy
+    # Create a polygon for each of the disconnected regions, called chunks in ContourPy
     # This iterates over the elements in three lists, the points, offsets, and outer offsets
     chunk_polygons = [
         shapely.from_ragged_array(


### PR DESCRIPTION
This adds a function to convert a binary mask to a shapely multipolygon and closes #30. It's inspired by @amrithasp02 's initial work using matplotlib and directly calls `ContourPy`, the library used by matplotlib. In the future we could explore other library implementations, but for now this seems relatively optimized and convenient. The function largely follows an example [here](https://contourpy.readthedocs.io/en/v1.3.0/user_guide/external/shapely.html#filled-contours-to-shapely).

I also added an example of using this function to visualize the boundaries of the predictions over the images. While it is not included in the tiles that are shown, I confirmed that this approach correctly handles both holes and multiple disconnected regions from the same mask. In both cases, all the information is represented in one `shapely.MultiPolygon`. As discussed, we could later post-process this to do things such as retaining the largest single component or filling holes.