### PR TITLE
Add Jupyter compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,14 @@ in the base conda environment or with no environment active.
 ```
 curl -sSL https://install.python-poetry.org | python3 -
 ```
-Now create and activate a conda environment for the dependencies of this project
+Now create and activate a conda environment for the dependencies of this project.
 ```
 conda create -n tree-detection-framework python=3.10 ipykernel -y
 conda activate tree-detection-framework
 ```
+ Including `ipykernel` as suggested enables you to access this conda environment as kernel for Jupyter notebooks, but it is otherwise optional.
+
+
 Now, from the root directory of the project, run the following command. Note that on Jetstream2, you
 may need to run this in a graphical session and respond to a keyring popup menu.
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ curl -sSL https://install.python-poetry.org | python3 -
 ```
 Now create and activate a conda environment for the dependencies of this project
 ```
-conda create -n tree-detection-framework python=3.10 -y
+conda create -n tree-detection-framework python=3.10 ipykernel -y
 conda activate tree-detection-framework
 ```
 Now, from the root directory of the project, run the following command. Note that on Jetstream2, you


### PR DESCRIPTION
Including `ipykernel` in the conda env enables this env to be discovered and used as a kernel for Jupyter notebooks. I'm not sure if Jupyter compatibility is enough of a priority to include this extra dependency in the default readme installation instructions. Thoughts?