### PR TITLE
Handle empty masks and polygons

### DIFF
--- a/tree_detection_framework/postprocessing/postprocessing.py
+++ b/tree_detection_framework/postprocessing/postprocessing.py
@@ -38,6 +38,9 @@ def single_region_NMS(
     # Extract the geodataframe for the detections
     detections_df = detections.get_data_frame()
 
+    # Remove all empty polygons if any
+    detections_df = detections_df[~detections_df.geometry.is_empty]
+
     # Determine which detections are high enough confidence to retain
     high_conf_inds = np.where(
         (detections_df[confidence_column] >= min_confidence).to_numpy()
@@ -285,6 +288,6 @@ def merge_and_postprocess_detections(
         new_polygons.append(new_polygon)
 
     # Create a RegionDetections for the merged and postprocessed detections
-    postprocessed_detections = RegionDetections(new_polygons, input_in_pixels=False)
+    postprocessed_detections = RegionDetections(new_polygons, input_in_pixels=False)  # add CRS from the df
 
     return postprocessed_detections

--- a/tree_detection_framework/utils/geometric.py
+++ b/tree_detection_framework/utils/geometric.py
@@ -38,6 +38,10 @@ def mask_to_shapely(mask: np.ndarray) -> shapely.MultiPolygon:
     # This generally follows the example here:
     # https://contourpy.readthedocs.io/en/v1.3.0/user_guide/external/shapely.html#filled-contours-to-shapely
 
+    # If mask is empty, return an empty Polygon
+    if not np.any(mask):
+        return shapely.Polygon()
+    
     # Extract the contours and create a filled contour for the regions above 0.5
     filled = contour_generator(z=mask, fill_type="ChunkCombinedOffsetOffset").filled(
         0.5, np.inf


### PR DESCRIPTION
Faced this issue while using `detectree2`. 
`mask_to_shapely()` gave errors when it received an empty mask.