### PR TITLE
Add option to return only tree top location in geometric detector

### DIFF
--- a/tree_detection_framework/detection/detector.py
+++ b/tree_detection_framework/detection/detector.py
@@ -737,11 +737,15 @@ class GeometricDetector(Detector):
                 final_tree_crowns, confidence_scores = self.get_tree_crowns(
                     image, treetop_pixel_coords, treetop_heights
                 )
-                batch_detections.append(final_tree_crowns)  # List[List[shapely.geometry]]
+                batch_detections.append(
+                    final_tree_crowns
+                )  # List[List[shapely.geometry]]
                 batch_detections_data.append({"score": confidence_scores})
             else:
                 # Otherwise, the geometry is just the location of the tree top as a point
-                batch_detections.append(treetop_pixel_coords)  # List[List[shapely.geometry]]
+                batch_detections.append(
+                    treetop_pixel_coords
+                )  # List[List[shapely.geometry]]
                 # And the score is the height
                 # TODO support could be added for the distance-from-edge metric
                 batch_detections_data.append({"score": treetop_heights})


### PR DESCRIPTION
Some applications may use just the tree tops and not the crown. It would be possible to record the location of the tree tops as an additional attribute, but these attributes would not be transformed to difference CRS in the same way as the geometry. Additionally, crown delineation takes more time than treetop detection. 

There may be a cleaner way to handle this in the future. 