### PR TITLE
Change how valid rows are computed for crown delineation

### DIFF
--- a/tree_detection_framework/detection/detector.py
+++ b/tree_detection_framework/detection/detector.py
@@ -790,14 +790,17 @@ class GeometricTreeCrownDetector(Detector):
             )
         ]
 
-        # Drop rows with invalid geometries, zero area polygons, and non-polygon geometries
-        tree_crown_gdf_cleaned = tree_crown_gdf_filtered[
-            tree_crown_gdf_filtered["tree_crown"].apply(
-                lambda geom: (
-                    isinstance(geom, Polygon) and geom.is_valid and geom.area > 0
-                )
-            )
-        ].reset_index(drop=True)
+        # Compute the three attributes of a valid row 1) the geometry is valid 2) the area is
+        # greater than 0 and 3) it is a polygon
+        valid_geometry = tree_crown_gdf_filtered.is_valid
+        nonzero_area = tree_crown_gdf_filtered.area > 0
+        is_polygon = tree_crown_gdf_filtered.geom_type == "Polygon"
+        # Take the logical and of all three attributes
+        valid_rows = valid_geometry & nonzero_area & is_polygon
+        # Retain only valid rows
+        tree_crown_gdf_cleaned = tree_crown_gdf_filtered[valid_rows].reset_index(
+            drop=True
+        )
 
         # Calculate pseudo-confidence scores for the detections
         confidence_scores = calculate_scores(


### PR DESCRIPTION
This closes #133. This issue arises when `tree_crown_gdf_filtered` has no rows. The problem happens in this [line](https://github.com/open-forest-observatory/tree-detection-framework/blob/0c6d4aee76e6406f6835b20c7db703b5979220ad/tree_detection_framework/detection/detector.py#L797) where we check for crowns having valid geometry, non-zero area, and being polygon type. If there are no rows, the result of `apply` has `geometry` type rather than `bool`. I guess since the function doesn't have anything to run on, the type of the series (which is empty) defaults to the type of the original geometry column. For some reason, this causes all the columns to be dropped, which leads to indexing errors later.

This explicitly computes a boolean series. When indexing with the `valid_rows` variable, all columns are retained, even if no rows are. 