### PR TITLE
Fix zero-length dataloader 

### DIFF
--- a/tree_detection_framework/preprocessing/preprocessing.py
+++ b/tree_detection_framework/preprocessing/preprocessing.py
@@ -84,17 +84,17 @@ class UnboundedGridGeoSampler(GridGeoSampler):
             self.size = (self.size[0] * self.res, self.size[1] * self.res)
             self.stride = (self.stride[0] * self.res, self.stride[1] * self.res)
 
-        self.hits = []
-        for hit in self.index.intersection(tuple(self.roi), objects=True):
-            if include_smaller_tiles is True:
-                # If including smaller tiles, append all hits regardless of size
-                self.hits.append(hit)
-            else:
-                # Otherwise, proceed like GridGeoSampler
+        # If including smaller tiles, append all hits regardless of size
+        if include_smaller_tiles is True:
+            self.hits = list(self.index.intersection(tuple(self.roi), objects=True))
+        else:
+            # Otherwise, behave like GridGeoSampler
+            self.hits = []
+            for hit in self.index.intersection(tuple(self.roi), objects=True):
                 bounds = BoundingBox(*hit.bounds)
                 if (
-                bounds.maxx - bounds.minx >= self.size[1]
-                and bounds.maxy - bounds.miny >= self.size[0]
+                    bounds.maxx - bounds.minx >= self.size[1]
+                    and bounds.maxy - bounds.miny >= self.size[0]
                 ):
                     self.hits.append(hit)
 
@@ -309,6 +309,7 @@ def create_intersection_dataloader(
     raster_data = CustomRasterDataset(raster_data, **kwargs)
 
     # Create an intersection dataset that combines the datasets
+    # Attributes such as resolution will be taken from the first dataset
     intersection_data = IntersectionDataset(raster_data, vector_data)
 
     # Create a sampler to generate contiguous tiles of the input dataset

--- a/tree_detection_framework/preprocessing/preprocessing.py
+++ b/tree_detection_framework/preprocessing/preprocessing.py
@@ -42,9 +42,10 @@ class UnboundedGridGeoSampler(GridGeoSampler):
     A variant of GridGeoSampler that optionally includes tiles smaller than the chip size.
 
     Default GridGeoSampler skips tiles that are too small to contain a full chip. Setting
-    `include_smaller_tiles=True` overrides this behavior, and ensures all tiles are included. 
+    `include_smaller_tiles=True` overrides this behavior, and ensures all tiles are included.
     This is useful for generating a single chip from an entire raster.
     """
+
     def __init__(
         self,
         dataset: GeoDataset,

--- a/tree_detection_framework/preprocessing/preprocessing.py
+++ b/tree_detection_framework/preprocessing/preprocessing.py
@@ -234,7 +234,7 @@ def create_intersection_dataloader(
     raster_data = CustomRasterDataset(raster_data, **kwargs)
 
     # Create an intersection dataset that combines the datasets
-    intersection_data = IntersectionDataset(vector_data, raster_data)
+    intersection_data = IntersectionDataset(raster_data, vector_data)
 
     # GridGeoSampler to get contiguous tiles
     sampler = GridGeoSampler(

--- a/tree_detection_framework/preprocessing/preprocessing.py
+++ b/tree_detection_framework/preprocessing/preprocessing.py
@@ -11,9 +11,15 @@ import rasterio
 import shapely
 import torch
 from torch.utils.data import DataLoader
-from torchgeo.datasets import BoundingBox, GeoDataset, IntersectionDataset, stack_samples, unbind_samples
+from torchgeo.datasets import (
+    BoundingBox,
+    GeoDataset,
+    IntersectionDataset,
+    stack_samples,
+    unbind_samples,
+)
 from torchgeo.samplers import GeoSampler, GridGeoSampler, Units
-from torchgeo.samplers.utils import tile_to_chips, _to_tuple
+from torchgeo.samplers.utils import _to_tuple, tile_to_chips
 from torchvision.transforms import ToPILImage
 
 from tree_detection_framework.constants import ARRAY_TYPE, BOUNDARY_TYPE, PATH_TYPE

--- a/tree_detection_framework/preprocessing/preprocessing.py
+++ b/tree_detection_framework/preprocessing/preprocessing.py
@@ -36,8 +36,9 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
 
+
 class UnboundedGridGeoSampler(GridGeoSampler):
-    """Samples elements in a grid-like fashion. 
+    """Samples elements in a grid-like fashion.
 
     This allows the full raster to be returned as a single tile.
     """


### PR DESCRIPTION
This involved overriding the `__init__` method of `GridGeoSampler` so that it can also have one single tile covering the entire raster. 