### PR TITLE
Fix invalid geometry during NMS

### DIFF
--- a/tree_detection_framework/postprocessing/postprocessing.py
+++ b/tree_detection_framework/postprocessing/postprocessing.py
@@ -43,6 +43,9 @@ def single_region_NMS(
     # Extract the geodataframe for the detections
     detections_df = detections.get_data_frame()
 
+    # Buffer by zero to fix any issues with invalid geometries
+    detections_df["geometry"] = detections_df.geometry.buffer(0)
+
     # Determine which detections are high enough confidence to retain
     # Get rows that are both high confidence and not empty
     not_empty_mask = ~detections_df.geometry.is_empty


### PR DESCRIPTION
Error from @russelldj while doing NMS:

`shapely.errors.GEOSException: TopologyException: unable to assign free hole to a shell at 688231.5603850988 4376822.3865695409`

As expected, this was caused by invalid geometry in the predictions. Buffering the `geometry` column by zero almost always fixes such issues.

@russelldj the parameters were:
```
CHIP_SIZE = 1000
CHIP_STRIDE = 250
RESOLUTION = 0.2
```
I verified that it works after the changes.