### PR TITLE
Feature/fes/vis detections script

### DIFF
--- a/tree_detection_framework/detection/region_detections.py
+++ b/tree_detection_framework/detection/region_detections.py
@@ -22,6 +22,7 @@ def plot_detections(
     CRS: Optional[pyproj.CRS] = None,
     plt_ax: Optional[plt.axes] = None,
     plt_show: bool = True,
+    plt_points: bool = False,
     visualization_column: Optional[str] = None,
     bounds_color: Optional[Union[str, np.array, pd.Series]] = None,
     detection_kwargs: dict = {},
@@ -42,6 +43,8 @@ def plot_detections(
             A pyplot axes to plot on. If not provided, one will be created. Defaults to None.
         plt_show (bool, optional):
             Whether to plot the result or just return it. Defaults to True.
+        plt_points (bool, optional):
+            Whether to plot the centroid points within the boundaries. Defaults to False.
         visualization_column (Optional[str], optional):
             Which column to visualize from the detections dataframe. Defaults to None.
         bounds_color (Optional[Union[str, np.array, pd.Series]], optional):
@@ -65,7 +68,7 @@ def plot_detections(
 
     # If no axes are provided, create new ones
     if plt_ax is None:
-        _, plt_ax = plt.subplots()
+        _, plt_ax = plt.subplots(figsize=(10, 8))
 
     # Show the raster if provided
     if raster_file is not None:
@@ -87,6 +90,16 @@ def plot_detections(
     # Use the .boundary attribute to plot just the border. This works since it's a geoseries,
     # not a geodataframe
     bounds.boundary.plot(ax=plt_ax, color=bounds_color, **bounds_kwargs)
+
+    # Plot the centroids if requested
+    if plt_points is True:
+        for i, row in data_frame.iterrows():
+            centroid = row.geometry.centroid
+            x, y = centroid.x, centroid.y
+            plt_ax.plot(x, y, "ro", markersize=1)
+            plt_ax.text(
+                x + 3, y, f"{i:03}", color="red", fontsize=4, ha="left", va="top"
+            )
 
     # Show if requested
     if plt_show:
@@ -300,6 +313,7 @@ class RegionDetections:
         CRS: Optional[pyproj.CRS] = None,
         plt_ax: Optional[plt.axes] = None,
         plt_show: bool = True,
+        plt_points: bool = False,
         visualization_column: Optional[str] = None,
         bounds_color: Optional[Union[str, np.array, pd.Series]] = None,
         detection_kwargs: dict = {},
@@ -316,6 +330,8 @@ class RegionDetections:
                 A pyplot axes to plot on. If not provided, one will be created. Defaults to None.
             plt_show (bool, optional):
                 Whether to plot the result or just return it. Defaults to True.
+            plt_points (bool, optional):
+                Whether to plot the centroid points within the boundaries. Defaults to False.
             visualization_column (Optional[str], optional):
                 Which column to visualize from the detections dataframe. Defaults to None.
             bounds_color (Optional[Union[str, np.array, pd.Series]], optional):
@@ -342,12 +358,13 @@ class RegionDetections:
         bounds = self.get_bounds(CRS)
 
         # Perform plotting and return the axes
-        plot_detections(
+        return plot_detections(
             data_frame=data_frame,
             bounds=bounds,
             CRS=data_frame.crs,
             plt_ax=plt_ax,
             plt_show=plt_show,
+            plt_points=plt_points,
             visualization_column=visualization_column,
             detection_kwargs=detection_kwargs,
             bounds_kwargs=bounds_kwargs,

--- a/tree_detection_framework/entrypoints/detect_in_raw_images.py
+++ b/tree_detection_framework/entrypoints/detect_in_raw_images.py
@@ -18,7 +18,7 @@ from tree_detection_framework.preprocessing.preprocessing import create_image_da
 MODEL_KEYS = ["detectree2", "deepforest", "sam2"]
 
 
-def main():
+def parse_args():
     parser = argparse.ArgumentParser(
         description="Detect trees in raw images using a specified model.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -36,8 +36,8 @@ def main():
     parser.add_argument(
         "--detectree-checkpoints",
         type=Path,
-        help="Path to detectree checkpoints, see repo README. E.g."
-        " 230103_randresize_full.pth. Only used if model_key == detectree",
+        help="Path to detectree checkpoints, see repo README."
+        " E.g. 230103_randresize_full.pth. Only used if model_key == detectree2",
     )
     parser.add_argument(
         "--chip_size", type=int, default=2200, help="Chip size for tiling images"
@@ -53,51 +53,91 @@ def main():
     )
     args = parser.parse_args()
 
-    assert args.image_dir.is_dir()
+    assert args.image_dir.is_dir(), f"image_dir {args.image_dir} is not a directory"
     args.out_dir.mkdir(parents=True, exist_ok=True)
+    if args.model_key == "detectree2":
+        assert (
+            args.detectree_checkpoints is not None
+        ), "--detectree-checkpoints required for detectree2 model"
+        assert args.detectree_checkpoints.is_file()
+    return args
 
+
+def main(
+    image_dir: Path,
+    out_dir: Path,
+    model_key: str,
+    detectree_checkpoints: Path,
+    chip_size: int,
+    chip_stride: int,
+    batch_size: int,
+) -> None:
+    """
+    Detect trees in raw images using a specified model and save detection results.
+
+    Args:
+        image_dir (Path): Directory containing raw images.
+        out_dir (Path): Directory to save detection results. Will be created if it does not already exist.
+        model_key (str): Model to use for detection.
+        detectree_checkpoints (Path or None): Path to detectree2 checkpoints. Required if model_key is 'detectree2'.
+        chip_size (int): Chip size for tiling images.
+        chip_stride (int): Chip stride for tiling images.
+        batch_size (int): Batch size for inference.
+
+    Raises:
+        ValueError: If an unknown model_key is provided.
+    """
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Detecting on device: {device}")
 
     # Create dataloader for raw images
     dataloader = create_image_dataloader(
-        images_dir=args.image_dir,
-        chip_size=args.chip_size,
-        chip_stride=args.chip_stride,
-        batch_size=args.batch_size,
+        images_dir=image_dir,
+        chip_size=chip_size,
+        chip_stride=chip_stride,
+        batch_size=batch_size,
     )
     print("Dataloader created")
 
     # Instantiate the model
-    if args.model_key == "deepforest":
+    if model_key == "deepforest":
         model_params = {"backbone": "retinanet", "num_classes": 1}
         module = DeepForestModule(model_params)
         module.to(device)
         detector = DeepForestDetector(module)
-    elif args.model_key == "detectree2":
-        assert args.detectree_checkpoints.is_file()
-        model_params = {"update_model": str(args.detectree_checkpoints)}
+    elif model_key == "detectree2":
+        model_params = {"update_model": str(detectree_checkpoints)}
         module = Detectree2Module(model_params)
         detector = Detectree2Detector(module)
-    elif args.model_key == "sam2":
+    elif model_key == "sam2":
         detector = SAMV2Detector(device=device)
     else:
-        raise ValueError(f"Unknown model key: {args.model_key}")
+        raise ValueError(f"Unknown model key: {model_key}")
     print("Model loaded")
 
     # Use predict_raw_drone_images to get per-image results
     detection_sets, files, bounds = detector.predict_raw_drone_images(dataloader)
 
-    # Filter detections
+    # For each image, remove detections that extend past the image bounds
     filtered_sets = remove_out_of_bounds_detections(detection_sets, bounds)
+    # For each image, suppress overlapping detections
     filtered_sets = [multi_region_NMS(rds) for rds in filtered_sets]
 
     # Save results for each image
     for rds, file in zip(filtered_sets, files):
-        out_path = args.out_dir / (Path(file).stem + ".gpkg")
+        out_path = out_dir / (Path(file).stem + ".gpkg")
         rds.save(out_path)
-    print(f"Detection regions saved to {args.out_dir}")
+    print(f"Detection regions saved to {out_dir}")
 
 
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(
+        image_dir=args.image_dir,
+        out_dir=args.out_dir,
+        model_key=args.model_key,
+        detectree_checkpoints=args.detectree_checkpoints,
+        chip_size=args.chip_size,
+        chip_stride=args.chip_stride,
+        batch_size=args.batch_size,
+    )

--- a/tree_detection_framework/entrypoints/detect_in_raw_images.py
+++ b/tree_detection_framework/entrypoints/detect_in_raw_images.py
@@ -1,5 +1,7 @@
 import argparse
+import logging
 from pathlib import Path
+import warnings
 
 import torch
 
@@ -111,6 +113,8 @@ def main(
         detector = Detectree2Detector(module)
     elif model_key == "sam2":
         detector = SAMV2Detector(device=device)
+        warnings.filterwarnings("ignore", message="cannot import name '_C' from 'sam2'")
+        logging.getLogger().setLevel(logging.WARNING)
     else:
         raise ValueError(f"Unknown model key: {model_key}")
     print("Model loaded")

--- a/tree_detection_framework/entrypoints/visualize_detections.py
+++ b/tree_detection_framework/entrypoints/visualize_detections.py
@@ -1,0 +1,118 @@
+import argparse
+from pathlib import Path
+import warnings
+
+import geopandas as gpd
+from rasterio.errors import NotGeoreferencedWarning
+from tqdm import tqdm
+
+from tree_detection_framework.detection.region_detections import RegionDetections
+
+# We know we don't care about these warnings from rasterio
+warnings.filterwarnings("ignore", category=NotGeoreferencedWarning)
+
+
+def visualize_detections(
+    image_dir, detection_dir, out_dir, n_images, step, show_centroid,
+):
+
+    # Get sorted lists of image and gpkg files
+    gpkg_paths = sorted(detection_dir.glob("*.gpkg"))
+
+    # Sample indices according to n_images and step
+    indices = [i for i in range(0, len(gpkg_paths), step)][:n_images]
+
+    for idx in tqdm(indices, f"Saving images to {out_dir}"):
+        gpkg_path = gpkg_paths[idx]
+        image_path = image_dir / (gpkg_path.stem + ".JPG")
+
+        detections = RegionDetections(
+            detection_geometries="geometry",
+            data=gpd.read_file(gpkg_path),
+        )
+
+        axis = detections.plot(
+            plt_show=False,
+            raster_file=image_path,
+            plt_points=show_centroid,
+            raster_vis_downsample=1,
+        )
+
+        figure = axis.get_figure()
+        figure.savefig(
+            out_dir / (gpkg_path.stem + ".png"), dpi=300, bbox_inches="tight"
+        )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Visualize detection results on raw images.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "image_dir",
+        type=Path,
+        help="Directory containing raw images.",
+    )
+    parser.add_argument(
+        "detection_dir",
+        type=Path,
+        help="Directory containing detection .gpkg files.",
+    )
+    parser.add_argument(
+        "out_dir",
+        type=Path,
+        help="Directory to save visualizations. Will be created if it does not exist.",
+    )
+    parser.add_argument(
+        "--n-images",
+        type=int,
+        default=5,
+        help="Number of images to visualize.",
+    )
+    parser.add_argument(
+        "--step",
+        type=int,
+        default=1,
+        help="Step size between visualized images.",
+    )
+    parser.add_argument(
+        "--no-centroid",
+        action="store_true",
+        help="Do not show centroid in visualization.",
+    )
+
+    args = parser.parse_args()
+
+    # Check that image_dir and detection_dir exist and are not empty
+    for dir_path in [args.image_dir, args.detection_dir]:
+        assert dir_path.is_dir(), f"{dir_path} not found"
+        assert any(dir_path.iterdir()), f"{dir_path} empty"
+
+    # Check that each detection file matches an image file (by stem, with .JPG extension)
+    image_stems = {p.stem for p in args.image_dir.glob("*.JPG")}
+    for gpkg_file in args.detection_dir.glob("*.gpkg"):
+        assert (
+            gpkg_file.stem in image_stems
+        ), f"No matching image for detection {gpkg_file}"
+
+    # Create out_dir if it doesn't exist
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    return args
+
+
+def main():
+    args = parse_args()
+    visualize_detections(
+        image_dir=args.image_dir,
+        detection_dir=args.detection_dir,
+        out_dir=args.out_dir,
+        n_images=args.n_images,
+        step=args.step,
+        show_centroid=not args.no_centroid,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Script to visualize a few TDF outputs (gpkg files).

Tested with
```
python3 tree_detection_framework/entrypoints/visualize_detections.py /ofo-share/scratch-eric/000936-01/00/ /ofo-share/scratch-eric/000936-01/rds-DF-ground-filtered/ /ofo-share/scratch-eric/000936-01/vis-rds-DF-ground-filtered/ --step 100 --n-images 14 --image-ext JPG
```

And it produced images like this:
<img width="2520" height="1889" alt="000936-01_000501" src="https://github.com/user-attachments/assets/8a55edb9-66dc-4344-8073-e22eeb103c0e" />
