### PR TITLE
Feature/fes/accept nested images

### DIFF
--- a/tests/test_derived_geodatasets.py
+++ b/tests/test_derived_geodatasets.py
@@ -102,8 +102,10 @@ class TestCustomImageDataset:
                 (32, 32, chip["bounds"]),
                 (128, 64, chip["metadata"]["image_bounds"]),
             ):
+                # See explanatory comments on derived_geodatasets.bounding_box on why
+                # we are doing miny - maxy
                 assert np.isclose(bounds.maxx - bounds.minx, exp_x)
-                assert np.isclose(bounds.maxy - bounds.miny, exp_y)
+                assert np.isclose(bounds.miny - bounds.maxy, exp_y)
 
         assert count == {"red": 8, "blue": 8}
 

--- a/tests/test_derived_geodatasets.py
+++ b/tests/test_derived_geodatasets.py
@@ -1,0 +1,205 @@
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from tree_detection_framework.preprocessing.derived_geodatasets import (
+    CustomImageDataset,
+)
+
+
+def create_image(path: Path, size=(100, 100), color="blue"):
+    img = Image.new("RGB", size, color=color)
+    img.save(path)
+    return path
+
+
+def create_nested_dirs(root):
+    """Create a commonly used subdir structure of
+    tmp_path/
+        root/
+            subdir/
+    """
+    root.mkdir(exist_ok=True)
+    subdir = root / "subdir"
+    subdir.mkdir()
+    return root, subdir
+
+
+class TestCustomImageDataset:
+
+    @pytest.mark.parametrize(
+        "image_extension", [".JPG", ".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"]
+    )
+    @pytest.mark.parametrize(
+        "from_dir,as_str",
+        [
+            (True, None),
+            (False, True),
+            (False, False),
+        ],
+    )
+    def test_dataset_basic(self, tmp_path, image_extension, from_dir, as_str):
+        """
+        Test the nested files
+        root/
+            img1.jpg
+            subdir/
+                img2.jpg
+        """
+
+        root, subdir = create_nested_dirs(tmp_path / "images")
+        img1 = create_image(
+            root / f"img1{image_extension}", size=(128, 64), color="blue"
+        )
+        img2 = create_image(
+            subdir / f"img1{image_extension}", size=(128, 64), color="red"
+        )
+
+        # Either serve the images from a root directory or as a list of paths
+        if from_dir:
+            source = root
+        else:
+            if as_str:
+                source = [str(img1), str(img2)]
+            else:
+                source = [img1, img2]
+
+        # Create the dataset
+        dataset = CustomImageDataset(
+            images_dir=source,
+            chip_size=32,
+            chip_stride=32,
+            labels_dir=None,
+        )
+
+        # Check that we have the proper number of chips, (128, 64) is 4x2
+        # and there were two images
+        assert len(dataset) == 16
+
+        # Check that we got colors from both images
+        count = {"red": 0, "blue": 0}
+        for chip in dataset:
+            # Reshape from (C, H, W) to (C, H * W) and average over pixels
+            color = chip["image"].reshape(3, -1).mean(axis=1)
+            if np.allclose(color, [1, 0, 0], atol=0.01):
+                count["red"] += 1
+            elif np.allclose(color, [0, 0, 1], atol=0.01):
+                count["blue"] += 1
+
+            # Check some typing
+            assert isinstance(chip["image"], torch.Tensor)
+            # And existence of certain fields
+            assert "metadata" in chip
+            assert "bounds" in chip
+            assert "annotations" not in chip["metadata"]
+            assert chip["crs"] is None
+
+        assert count == {"red": 8, "blue": 8}
+
+    @pytest.mark.parametrize("as_str", [True, False])
+    def test_dataset_labels_bad(self, tmp_path, as_str):
+        """
+        Check that if labels are given but they don't match the image structure,
+        an error is raised.
+        """
+
+        # Two images, one in a subdirectory
+        imroot, imsub = create_nested_dirs(tmp_path / "images")
+        img1 = create_image(imroot / "img1.jpg", size=(128, 64), color="blue")
+        img2 = create_image(imsub / "img1.jpg", size=(128, 64), color="red")
+
+        # Two label files
+        labroot, labsub = create_nested_dirs(tmp_path / "labels")
+        label_paths = [labroot / "img1.geojson", labroot / "img2.geojson"]
+        for path in label_paths:
+            path.write_text('{"type": "FeatureCollection", "features": []}')
+        if as_str:
+            label_paths = [str(path) for path in label_paths]
+
+        with pytest.raises(ValueError):
+            CustomImageDataset(
+                images_dir=[img1, img2],
+                chip_size=32,
+                chip_stride=32,
+                labels_dir=label_paths,
+            )
+
+    @pytest.mark.parametrize(
+        "from_dir,as_str",
+        [
+            (True, None),
+            (False, True),
+            (False, False),
+        ],
+    )
+    def test_dataset_labels(self, tmp_path, from_dir, as_str):
+        """
+        Check that if labels are given an annotation field is added
+        """
+
+        # Two images, one in a subdirectory
+        imroot, imsub = create_nested_dirs(tmp_path / "images")
+        img1 = create_image(imroot / "img1.jpg", size=(128, 64))
+        img2 = create_image(imsub / "img1.jpg", size=(128, 64))
+
+        # Two label files
+        labroot, labsub = create_nested_dirs(tmp_path / "labels")
+        label_paths = [labroot / "img1.geojson", labsub / "img1.geojson"]
+        for path in label_paths:
+            path.write_text('{"type": "FeatureCollection", "features": []}')
+        if as_str:
+            label_paths = [str(path) for path in label_paths]
+
+        # Either serve the images from a root directory or as a list of paths
+        if from_dir:
+            source = imroot
+        else:
+            if as_str:
+                source = [str(img1), str(img2)]
+            else:
+                source = [img1, img2]
+
+        dataset = CustomImageDataset(
+            images_dir=source,
+            chip_size=32,
+            chip_stride=32,
+            labels_dir=label_paths,
+        )
+        assert len(dataset) == 16
+
+        output_paths = []
+        for chip in dataset:
+            assert "annotations" in chip["metadata"]
+            assert isinstance(chip["metadata"]["annotations"], str)
+            output_paths.append(chip["metadata"]["annotations"])
+
+        # Multiple chips will have a single label file, so we can check sets - are
+        # all of the input labels matched to some chip?
+        assert set(output_paths) == set(map(str, label_paths))
+
+    def test_dataset_padding_at_edge(self, tmp_path):
+        img_path = create_image(tmp_path / "small.jpg", size=(40, 40), color="black")
+
+        dataset = CustomImageDataset(
+            images_dir=[str(img_path)],
+            chip_size=32,
+            chip_stride=30,
+        )
+
+        # Padding should turn this into 4 chips, 3 heavily padded
+        assert len(dataset) == 4
+
+        means = []
+        for chip in dataset:
+            assert chip["image"].shape[1:] == (
+                32,
+                32,
+            ), "Tile should always match chip_size even with padding"
+            means.append(chip["image"].mean())
+
+        # As the image fills with white padding the average should go up
+        assert np.allclose(sorted(means), [0, 0.7, 0.7, 0.9], atol=0.05)

--- a/tests/test_derived_geodatasets.py
+++ b/tests/test_derived_geodatasets.py
@@ -12,6 +12,7 @@ from tree_detection_framework.preprocessing.derived_geodatasets import (
 
 
 def create_image(path: Path, size=(100, 100), color="blue"):
+    # Note that size is in (x, y) = (width, height)
     img = Image.new("RGB", size, color=color)
     img.save(path)
     return path
@@ -94,9 +95,15 @@ class TestCustomImageDataset:
             assert isinstance(chip["image"], torch.Tensor)
             # And existence of certain fields
             assert "metadata" in chip
-            assert "bounds" in chip
             assert "annotations" not in chip["metadata"]
             assert chip["crs"] is None
+            # Check that the chip and image bounds are consistent
+            for exp_x, exp_y, bounds in (
+                (32, 32, chip["bounds"]),
+                (128, 64, chip["metadata"]["image_bounds"]),
+            ):
+                assert np.isclose(bounds.maxx - bounds.minx, exp_x)
+                assert np.isclose(bounds.maxy - bounds.miny, exp_y)
 
         assert count == {"red": 8, "blue": 8}
 

--- a/tree_detection_framework/entrypoints/detect_in_raw_images.py
+++ b/tree_detection_framework/entrypoints/detect_in_raw_images.py
@@ -25,12 +25,17 @@ def parse_args():
         description="Detect trees in raw images using a specified model.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("image_dir", type=Path, help="Directory containing raw images.")
+    parser.add_argument(
+        "image_dir",
+        type=Path,
+        help="Directory containing raw images, or nested subdirectories with raw"
+        " images in them. Will read all images recusively from this directory.")
     parser.add_argument(
         "out_dir",
         type=Path,
         help="Directory to save detection results. Will be created if it does"
-        " not already exist.",
+        " not already exist. The subdirectory structure of image_dir will be"
+        " mirrored, if there is any.",
     )
     parser.add_argument(
         "model_key", type=str, choices=MODEL_KEYS, help=f"Model to use: {MODEL_KEYS}"
@@ -78,8 +83,11 @@ def main(
     Detect trees in raw images using a specified model and save detection results.
 
     Args:
-        image_dir (Path): Directory containing raw images.
-        out_dir (Path): Directory to save detection results. Will be created if it does not already exist.
+        image_dir (Path): Directory containing raw images, or nested subdirectories with raw
+            images in them. Will read all images recusively from this directory.
+        out_dir (Path): Directory to save detection results. Will be created if it does
+            not already exist. The subdirectory structure of image_dir will be mirrored,
+            if there is any.
         model_key (str): Model to use for detection.
         detectree_checkpoints (Path or None): Path to detectree2 checkpoints. Required if model_key is 'detectree2'.
         chip_size (int): Chip size for tiling images.
@@ -127,9 +135,15 @@ def main(
     # For each image, suppress overlapping detections
     filtered_sets = [multi_region_NMS(rds) for rds in filtered_sets]
 
-    # Save results for each image
+    # Save results for each image. We want to replicate the nested subdirectory
+    # structure of the input images
     for rds, file in zip(filtered_sets, files):
-        out_path = out_dir / (Path(file).stem + ".gpkg")
+        # Get the potentially nested path from the root image directory
+        relative_image_path = Path(file).relative_to(image_dir)
+        # Rebuild that same subdirectory structure in the output folder
+        out_path = out_dir / relative_image_path.with_suffix(".gpkg")
+        # Make sure the subdirectory exists and save
+        out_path.parent.mkdir(exist_ok=True, parents=True)
         rds.save(out_path)
     print(f"Detection regions saved to {out_dir}")
 

--- a/tree_detection_framework/entrypoints/detect_in_raw_images.py
+++ b/tree_detection_framework/entrypoints/detect_in_raw_images.py
@@ -29,7 +29,8 @@ def parse_args():
         "image_dir",
         type=Path,
         help="Directory containing raw images, or nested subdirectories with raw"
-        " images in them. Will read all images recusively from this directory.")
+        " images in them. Will read all images recusively from this directory.",
+    )
     parser.add_argument(
         "out_dir",
         type=Path,

--- a/tree_detection_framework/preprocessing/derived_geodatasets.py
+++ b/tree_detection_framework/preprocessing/derived_geodatasets.py
@@ -1,4 +1,5 @@
 import logging
+import os.path
 import tempfile
 from collections import defaultdict, namedtuple
 from pathlib import Path
@@ -196,7 +197,7 @@ class CustomVectorDataset(VectorDataset):
 class CustomImageDataset(Dataset):
     def __init__(
         self,
-        images_dir: Union[PATH_TYPE, List[str]],
+        images_dir: Union[PATH_TYPE, List[PATH_TYPE]],
         chip_size: int,
         chip_stride: int,
         labels_dir: Optional[List[str]] = None,
@@ -205,7 +206,15 @@ class CustomImageDataset(Dataset):
         Dataset for creating a dataloader from a folder of individual images, with an option to create tiles.
 
         Args:
-            images_dir (Union[Path, List[str]]): Path to the folder containing image files, or list of paths to image files.
+            images_dir (Union[Path, List[PATH_TYPE]]): Path to a folder containing potentially nested
+                image files, or list of paths to image files. By 'nested' image files, that means that
+                images could reside in arbitrarily nested subdirectories and this dataset should iterate
+                over all of them. E.g.
+                    images_dir/
+                        subdir1/
+                            [images]
+                        subdir2/
+                            [images]
             chip_size (int): Dimension of each image chip (width, height) in pixels.
             chip_stride (int): Stride to take while chipping the images (horizontal, vertical) in pixels.
             labels_dir (Optional[List[str]]): List of paths to annotation .geojson files corresponding to the images.
@@ -221,7 +230,7 @@ class CustomImageDataset(Dataset):
             self.image_paths = sorted(
                 [
                     path
-                    for path in self.images_dir.glob("*")
+                    for path in self.images_dir.glob("**/*")
                     if path.suffix.lower() in image_extensions
                 ]
             )
@@ -229,26 +238,46 @@ class CustomImageDataset(Dataset):
             if len(self.image_paths) == 0:
                 raise ValueError(f"No image files found in {self.images_dir}")
         else:
+            # Save this input as the list of image paths we want to iterate over
             self.image_paths = images_dir
+            # Calculate the root of the images
+            self.images_dir = Path(os.path.commonpath(self.image_paths))
 
         self.labels_paths = labels_dir
-        self.tile_metadata = self._get_metadata()
+        self.tile_metadata = self._get_metadata(image_root=self.images_dir)
 
-    def _get_metadata(self):
+    def _get_metadata(self, image_root: PATH_TYPE):
+        """
+        Create a metadata entry for each image. If label paths are provided, check that
+        each maps to an image and include it in the entry.
+
+        Arguments:
+            image_root (PATH_TYPE): Should be the root directory where all images
+                are nested under. We assert that the labels files should have
+                a similar root, and the labels structure beneath that root should
+                match that of the images.
+        """
+
+        # Prepare some necessary structures if labels are provided
+        if self.labels_paths is not None:
+            label_root = Path(os.path.commonpath(self.labels_paths))
+            label_pathset = set([str(path) for path in self.labels_paths])
+
         metadata = []
         for img_path in self.image_paths:
-            # Ensure the label path corresponds to the same file name as the image
+
+            # If label paths were given, ensure the paths corresponds to the same
+            # nested path as each image
             label_path = None
-            if self.labels_paths:
+            if self.labels_paths is not None:
                 # Match the label file by replacing the image extension with `.geojson`
-                expected_label_name = img_path.stem + ".geojson"
-                matching_labels = filter(
-                    lambda label: Path(label).name == expected_label_name,
-                    self.labels_paths,
-                )
-                label_path = next(matching_labels, None)
-                if label_path is None:
-                    raise ValueError(f"Label file not found for image: {img_path}")
+                # and mimicking the directory structure
+                subpath = Path(img_path).relative_to(image_root)
+                label_path = (label_root / subpath).with_suffix(".geojson")
+                if str(label_path) not in label_pathset:
+                    raise ValueError(
+                        f"Label file [{label_path}] not found for image: [{img_path}]"
+                    )
 
             tile_idx = 0  # A unique tile index value within this image, resets for every new image
             with Image.open(img_path) as img:
@@ -260,6 +289,7 @@ class CustomImageDataset(Dataset):
                         # Add metadata for the current tile
                         metadata.append((tile_idx, img_path, label_path, x, y))
                         tile_idx += 1
+
         return metadata
 
     def __len__(self):

--- a/tree_detection_framework/preprocessing/derived_geodatasets.py
+++ b/tree_detection_framework/preprocessing/derived_geodatasets.py
@@ -34,6 +34,9 @@ logging.basicConfig(
 )
 
 # Define a namedtuple to store bounds of tiles images from the `CustomImageDataset`
+# Note that the y min bounds are reversed from the expected convention. This is because they are
+# measured in pixel coordinates, which start at the top and go down. So this convention matches
+# how the geospatial bounding box is represented.
 bounding_box = namedtuple("bounding_box", ["minx", "maxx", "miny", "maxy"])
 
 
@@ -329,8 +332,8 @@ class CustomImageDataset(Dataset):
                 "image_bounds": bounding_box(
                     0,
                     float(img.width),
-                    0,
                     float(img.height),
+                    0,
                 ),
             }
             if self.labels_paths is not None:
@@ -343,8 +346,8 @@ class CustomImageDataset(Dataset):
                 "bounds": bounding_box(
                     float(x),
                     float(x + self.chip_size),
-                    float(y),
                     float(y + self.chip_size),
+                    float(y),
                 ),
                 "crs": None,
             }


### PR DESCRIPTION
Original goal of this PR: https://github.com/open-forest-observatory/tree-detection-framework/issues/145

I started off by testing on this nested subdirectory structure:
```
root_image_dir/
    000936-01/
        00/
            [images]
    000936-02/
        00/
            [images]

root_image_dir$ ls */*
000936-01/00:
000936-01_001000.JPG  000936-01_001001.JPG  000936-01_001003.JPG  000936-01_001004.JPG
000936-02/00:
000936-01_001000.JPG  000936-01_001001.JPG  000936-01_001003.JPG  000936-01_001004.JPG
```

And can confirm that the output both 1) got all the images 2) replicated the nested structure on the output:

```
$ ls /ofo-share/scratch-eric/tmp/*/*

/ofo-share/scratch-eric/tmp/000936-01/00:
000936-01_001000.gpkg  000936-01_001001.gpkg  000936-01_001003.gpkg  000936-01_001004.gpkg

/ofo-share/scratch-eric/tmp/000936-02/00:
000936-01_001000.gpkg  000936-01_001001.gpkg  000936-01_001003.gpkg  000936-01_001004.gpkg
```

Here was the command given:
```
python3 tree_detection_framework/entrypoints/detect_in_raw_images.py     /ofo-share/scratch-eric/TINY_IMAGES/     /ofo-share/scratch-eric/tmp/     deepforest     --batch_size 10
```

I also wanted to test that the original flat structure would still work, where you give a folder with only images and get back a folder with only detections, so I pointed the script to one of the subdirectories, and confirmed that the output was only detections:

Command:
```
python3 tree_detection_framework/entrypoints/detect_in_raw_images.py     /ofo-share/scratch-eric/TINY_IMAGES/000936-01/00/    /ofo-share/scratch-eric/tmp/     deepforest     --batch_size 10
```

Output:
```
$ ls /ofo-share/scratch-eric/tmp/

000936-01_001000.gpkg  000936-01_001001.gpkg  000936-01_001003.gpkg  000936-01_001004.gpkg
```