### PR TITLE
Feature/fes/ellipse filter

### DIFF
--- a/tests/test_geometric.py
+++ b/tests/test_geometric.py
@@ -1,0 +1,54 @@
+import numpy as np
+
+from tree_detection_framework.utils import ellipse_mask
+
+
+class TestEllipseMask:
+    def test_basic(self):
+
+        # Create the ellipse
+        shape = (40, 60)
+        center = (10, 20)
+        axes = (10, 3)
+        mask = ellipse_mask(shape, center, axes)
+
+        # Check types and shapes
+        assert isinstance(mask, np.ndarray)
+        assert mask.dtype == bool
+        assert mask.shape == shape
+
+        # Check a few points in the mask
+        assert mask[10, 20] is True
+        # X
+        assert mask[8, 20] is True
+        assert mask[18, 20] is True
+        assert mask[22, 20] is False
+        # Y
+        assert mask[10, 18] is True
+        assert mask[10, 22] is True
+        assert mask[10, 15] is False
+        assert mask[10, 25] is False
+
+    def test_angles(self):
+
+        # Create the ellipse with two angles
+        shape = (60, 60)
+        center = (30, 30)
+        axes = (300, 5)
+        angle = np.deg2rad(45)
+        mask_p45 = ellipse_mask(shape, center, axes, angle)
+        mask_n45 = ellipse_mask(shape, center, axes, -angle)
+
+        # Check the diagonals for +45
+        assert mask_p45[5, 5] is False
+        assert mask_p45[55, 55] is False
+        assert mask_p45[30, 30] is True
+        assert mask_p45[55, 5] is True
+        assert mask_p45[5, 55] is True
+
+        # Check the diagonals for -45
+        assert mask_p45[5, 5] is True
+        assert mask_p45[55, 55] is True
+        assert mask_p45[30, 30] is True
+        assert mask_p45[55, 5] is False
+        assert mask_p45[5, 55] is False

--- a/tests/test_geometric.py
+++ b/tests/test_geometric.py
@@ -1,12 +1,14 @@
 import numpy as np
 
-from tree_detection_framework.utils import ellipse_mask
+from tree_detection_framework.utils.geometric import ellipse_mask
 
 
 class TestEllipseMask:
     def test_basic(self):
 
-        # Create the ellipse
+        # Create the ellipse. Note that the center is defined in terms of
+        # (x, y), but then we will need to index into the image with (y, x)
+        # a.k.a. (i, j)
         shape = (40, 60)
         center = (10, 20)
         axes = (10, 3)
@@ -18,16 +20,16 @@ class TestEllipseMask:
         assert mask.shape == shape
 
         # Check a few points in the mask
-        assert mask[10, 20] is True
+        assert bool(mask[20, 10]) is True
         # X
-        assert mask[8, 20] is True
-        assert mask[18, 20] is True
-        assert mask[22, 20] is False
+        assert bool(mask[20, 8]) is True
+        assert bool(mask[20, 18]) is True
+        assert bool(mask[20, 22]) is False
         # Y
-        assert mask[10, 18] is True
-        assert mask[10, 22] is True
-        assert mask[10, 15] is False
-        assert mask[10, 25] is False
+        assert bool(mask[18, 10]) is True
+        assert bool(mask[22, 10]) is True
+        assert bool(mask[15, 10]) is False
+        assert bool(mask[25, 10]) is False
 
     def test_angles(self):
 
@@ -40,15 +42,15 @@ class TestEllipseMask:
         mask_n45 = ellipse_mask(shape, center, axes, -angle)
 
         # Check the diagonals for +45
-        assert mask_p45[5, 5] is False
-        assert mask_p45[55, 55] is False
-        assert mask_p45[30, 30] is True
-        assert mask_p45[55, 5] is True
-        assert mask_p45[5, 55] is True
+        assert bool(mask_p45[5, 5]) is False
+        assert bool(mask_p45[55, 55]) is False
+        assert bool(mask_p45[30, 30]) is True
+        assert bool(mask_p45[55, 5]) is True
+        assert bool(mask_p45[5, 55]) is True
 
         # Check the diagonals for -45
-        assert mask_p45[5, 5] is True
-        assert mask_p45[55, 55] is True
-        assert mask_p45[30, 30] is True
-        assert mask_p45[55, 5] is False
-        assert mask_p45[5, 55] is False
+        assert bool(mask_n45[5, 5]) is True
+        assert bool(mask_n45[55, 55]) is True
+        assert bool(mask_n45[30, 30]) is True
+        assert bool(mask_n45[55, 5]) is False
+        assert bool(mask_n45[5, 55]) is False

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -105,7 +105,7 @@ def check_expected_rds(rds, use_rds, expected_indices):
 
     if use_rds is True:
         # In this case we should have recieved a list of RDS objects, one
-        # per image (and on RD per chip)
+        # per image (and one RD per chip)
         assert isinstance(rds, RegionDetectionsSet)
         for rd in rds.region_detections:
             assert set(rd.get_data_frame().index) == set(expected_indices)

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -1,12 +1,12 @@
 from itertools import cycle
 from typing import List, Tuple, Union
 
-import geopandas as gpd
 import numpy as np
 import pytest
 from PIL import Image
 from shapely.geometry import box
 
+import geopandas as gpd
 from tree_detection_framework.constants import PATH_TYPE
 from tree_detection_framework.detection.region_detections import (
     RegionDetections,
@@ -14,7 +14,9 @@ from tree_detection_framework.detection.region_detections import (
 )
 from tree_detection_framework.postprocessing.postprocessing import (
     remove_masked_detections,
+    viewpoint_ellipse_suppression,
 )
+from tree_detection_framework.utils.geometric import ellipse_mask
 
 
 def make_detections(
@@ -37,10 +39,7 @@ def make_detections(
     if return_gdf is True:
         return gdf
     else:
-        return RegionDetections(
-            detection_geometries=None,
-            data=gdf,
-        )
+        return RegionDetections(detection_geometries=None, data=gdf)
 
 
 def make_mask_image(
@@ -77,15 +76,9 @@ def make_mask_image(
 
 
 class TestRemoveMaskedDetections:
-
     @pytest.mark.parametrize(
         "use_rds,geo_extension",
-        (
-            [True, None],
-            [False, ".gpkg"],
-            [False, ".geojson"],
-            [False, ".shp"],
-        ),
+        ([True, None], [False, ".gpkg"], [False, ".geojson"], [False, ".shp"]),
     )
     @pytest.mark.parametrize("flat", (True, False))
     @pytest.mark.parametrize("valid_classes", ([2], [1, 2, 3], [100, 5, 20]))
@@ -146,11 +139,7 @@ class TestRemoveMaskedDetections:
             make_mask_image(
                 path=file_dir / f"image_{i}.png",
                 valid_classes=valid_classes,
-                corners=[
-                    (0, 0, 50, 30),
-                    (50, 30, 100, 60),
-                    (100, 60, 120, 100),
-                ],
+                corners=[(0, 0, 50, 30), (50, 30, 100, 60), (100, 60, 120, 100)],
                 shape=[100, 120],
             )
 
@@ -195,3 +184,88 @@ class TestRemoveMaskedDetections:
                     # per image
                     assert isinstance(rds, gpd.GeoDataFrame)
                     assert set(rds.index) == set(range(max_expected_index + 1))
+
+
+class TestViewpointEllipseSuppression:
+    @pytest.mark.parametrize("ellipse_radius", [10, 30, 50])
+    @pytest.mark.parametrize("flat", (True, False))
+    def test_basic(self, tmp_path, flat, ellipse_radius):
+
+        # Test the following code on N different masks. It doesn't matter that they
+        # are all the same, I just want to make sure that it works on multiple
+        N = 3
+
+        # Test whether this works in a flat directory where the files are directly
+        # present (flat = True) and when given nested subdirectory files (flat = False)
+        if flat is True:
+            file_dir = tmp_path
+        else:
+            file_dir = tmp_path / "mission" / "00" / "folder"
+            file_dir.mkdir(parents=True)
+
+        # Make the detections that we want to filter
+        corners = [
+            (70, 70, 80, 80),  # Always in
+            (50, 70, 60, 80),  # In for [30, 50] radii
+            (90, 70, 100, 80),  # In for [30, 50] radii
+            (70, 50, 80, 60),  # In for [30, 50] radii
+            (70, 90, 80, 100),  # In for [30, 50] radii
+            (110, 70, 120, 80),  # In for [50] radius
+            (30, 70, 40, 80),  # In for [50] radius
+            (70, 110, 80, 120),  # In for [50] radius
+            (70, 30, 80, 40),  # In for [50] radius
+            (0, 10, 0, 10),  # Always out
+            (140, 150, 140, 150),  # Always out
+        ]
+
+        # Test both that the function works when given a list of RDS objects, and also that it
+        # works when given a list of geospatial files.
+        if use_rds is True:
+            detection_list = [
+                RegionDetectionsSet(
+                    region_detections=[
+                        make_detections(corners, return_gdf=False) for _ in range(N)
+                    ]
+                )
+                for _ in range(N)
+            ]
+        else:
+            detection_data = [
+                make_detections(corners, return_gdf=True) for _ in range(N)
+            ]
+            # Write the data out as geospatial files and return the file paths
+            detection_list = [file_dir / f"image_{i}.{geo_extension}" for i in range(N)]
+            for path, gdf in zip(detection_list, detection_data):
+                gdf.to_file(path)
+
+        # Create a variably sized ellipse mask
+        ellipse = ellipse_mask(
+            image_shape=(150, 150),
+            center=(75, 75),
+            axes=(ellipse_radius, ellipse_radius),
+        )
+
+        # Filter the detections. We know that as the threshold goes up we should
+        # get fewer detections remaining
+        filtered_detection_list = viewpoint_ellipse_suppression(
+            region_detection_sets=detection_list, ellipse=ellipse, threshold=0.5
+        )
+
+        # Check that we kept the expected rows. Based on the radius of the
+        # constructed ellipse we know what the kept indices should be.
+        expected_map = {10: [0], 30: [0, 1, 2, 3, 4], 50: [0, 1, 2, 3, 4, 5, 6, 7, 8]}
+        for rds in filtered_detection_list:
+
+            if use_rds is True:
+                # In this case we should have recieved a list of RDS objects, one
+                # per image (and on RD per chip)
+                assert isinstance(rds, RegionDetectionsSet)
+                for rd in rds.region_detections:
+                    assert set(rd.get_data_frame().index) == set(
+                        expected_map[ellipse_radius]
+                    )
+            else:
+                # In this case we should have recieved a list of GDF dataframes, one
+                # per image
+                assert isinstance(rds, gpd.GeoDataFrame)
+                assert set(rds.index) == set(expected_map[ellipse_radius])

--- a/tree_detection_framework/postprocessing/postprocessing.py
+++ b/tree_detection_framework/postprocessing/postprocessing.py
@@ -1,18 +1,18 @@
 import logging
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Iterable, List, Optional, Union
 
+import geopandas as gpd
 import numpy as np
+import rasterstats
+from affine import Affine
+from geopandas import GeoDataFrame
 from PIL import Image
+from polygone_nms import nms
 from shapely import box
 from shapely.geometry import MultiPolygon, Polygon
 from shapely.ops import unary_union
 
-import geopandas as gpd
-import rasterstats
-from affine import Affine
-from geopandas import GeoDataFrame
-from polygone_nms import nms
 from tree_detection_framework.constants import PATH_TYPE
 from tree_detection_framework.detection.region_detections import (
     RegionDetections,
@@ -27,7 +27,7 @@ def single_region_NMS(
     min_confidence: float = 0.3,
     intersection_method: str = "IOU",
 ) -> RegionDetections:
-    """Run non-max suppresion on predictions from a single region.
+    """Run non-max suppression on predictions from a single region.
 
     Args:
         detections (RegionDetections):
@@ -101,7 +101,7 @@ def multi_region_NMS(
     min_confidence: float = 0.3,
     intersection_method: str = "IOU",
 ) -> RegionDetections:
-    """Run non-max suppresion on predictions from multiple regions.
+    """Run non-max suppression on predictions from multiple regions.
 
     Args:
         detections (RegionDetectionsSet):
@@ -546,7 +546,7 @@ def remove_edge_detections(
     return updated_rds
 
 
-def remove_masked_detections(
+def remove_maskfile_detections(
     region_detection_sets: Union[List[RegionDetectionsSet], List[PATH_TYPE]],
     image_root: PATH_TYPE,
     image_paths: List[PATH_TYPE],
@@ -600,25 +600,65 @@ def remove_masked_detections(
             f" and region detection sets ({len(region_detection_sets)})"
         )
 
+    def mask_iterator():
+        """Helper function to generate the masks from file paths."""
+
+        # Iterate over each path to a specific image
+        for im_path in image_paths:
+
+            # Assuming the mask path relative to the mask root matches the
+            # image path relative to the image root, open the mask file
+            subpath = Path(im_path).relative_to(image_root)
+            mask_path = (mask_root / subpath).with_suffix(mask_extension)
+
+            # Calculate a mask which is True where the data is valid, a.k.a.
+            # in the parts of the image we think could contain good detections.
+            # Open the image as grayscale
+            mask_img = Image.open(mask_path).convert("L")
+            mask = np.isin(mask_img, valid_classes)
+
+            yield mask
+
+    return remove_masked_detections(
+        region_detection_sets=region_detection_sets,
+        mask_iterator=mask_iterator(),
+        threshold=threshold,
+    )
+
+
+def remove_masked_detections(
+    region_detection_sets: Union[List[RegionDetectionsSet], List[PATH_TYPE]],
+    mask_iterator: Iterable[np.ndarray],
+    threshold: float = 0.4,
+) -> List[RegionDetectionsSet]:
+    """
+    Filters out detections that marked as invalid in the given masks.
+
+    Args:
+        region_detection_sets (Union[List[RegionDetectionSet], List[PATH_TYPE]])
+            Each element is a RegionDetectionsSet derived from a specific drone image,
+            or a geospatial file containing the detections from a drone image.
+            Length is the number of raw drone images given to  the dataloader.
+        mask_iterator (Iterable[np.ndarray])
+            Iterator of masks of shape (height, width), dtype bool. Should be the
+            same length as the region_detection_sets. The areas in which we wish to
+            keep detections should be True. In order to be effective, these should be
+            the same size as the images the detections were created from.
+        threshold (float)
+            If the overlap of a given detection polygon with "valid" portions of the
+            mask is greater than the threshold, keep that detection. If not, filter
+            it out. Defaults to 0.4.
+
+    Returns:
+        List of RegiondetectionSet objects with masked predictions filtered out (one per
+        image) OR list of geospatial dataframes (one per image). This is based on the
+        input type of region_detection_sets
+    """
+
     filtered_sets = []
 
-    # Iterate over [0] the path to a specific image and [2] the
-    # RegionDetectionsSet of detections in that image
-    for im_path, rds in zip(image_paths, region_detection_sets):
-
-        # Assuming the mask path relative to the mask root matches the
-        # image path relative to the image root, open the mask file
-        subpath = Path(im_path).relative_to(image_root)
-        mask_path = (mask_root / subpath).with_suffix(mask_extension)
-
-        # Calculate a mask which is 1 where the data is valid, a.k.a.
-        # in the parts of the image we think could contain good detections.
-        # Open the image as grayscale
-        mask_img = Image.open(mask_path).convert("L")
-        # Make the mask integer so that we can do math on the detections.
-        # For example, if a detection is 50+% valid, the mean value within
-        # the polygon will be 0.5+ because the mask is in numbers.
-        mask = np.isin(mask_img, valid_classes).astype(int)
+    # Iterate over the RegionDetectionsSet objects
+    for rds, mask in zip(region_detection_sets, mask_iterator):
 
         # Define a transformation from the image space ([0, 0] at the top left,
         # y increases going down) to rasterstats ([0, 0] at the bottom left,
@@ -657,103 +697,9 @@ def remove_masked_detections(
 
             # Get the mean value of each detection polygon, as a list of
             # [{"mean": <value>}, ...]
-            stats = rasterstats.zonal_stats(
-                gdf, mask.astype(int)[::-1, ...], stats=["mean"], affine=transform
-            )
-
-            # Get indices that have a greater fraction of good pixels than the
-            # threshold requires.
-            good_indices = [
-                i for i, stat in enumerate(stats) if stat["mean"] > threshold
-            ]
-
-            if isinstance(rds, RegionDetectionsSet):
-                # Subset the RegionDetections object keeping only the valid indices
-                rd = rds.get_region_detections(idx)
-                filtered_rd = rd.subset_detections(good_indices)
-                filtered_regions.append(filtered_rd)
-            else:
-                # Take a subset of the dataframe rows that we know are valid
-                filtered_regions.append(gdf.iloc[good_indices])
-
-        if isinstance(rds, RegionDetectionsSet):
-            # If we were passed a list of RegionDetectionsSet items, then we want
-            # to recreate that for the output with filtered RDS items
-            filtered_sets.append(RegionDetectionsSet(filtered_regions))
-        else:
-            # Otherwise, if we were passed a list of GDF paths, return a list
-            # of filtered GDF items
-            filtered_sets.extend(filtered_regions)
-
-    return filtered_sets
-
-
-def viewpoint_ellipse_suppression(
-    region_detection_sets: Union[List[RegionDetectionsSet], List[PATH_TYPE]],
-    ellipse: np.ndarray,
-    threshold: float = 0.4,
-) -> List[RegionDetectionsSet]:
-    """
-    Filters out detections that marked as invalid in the given ellipse mask.
-    In general it could be useful to limit detections to the center of the
-    image when high accuracy is required because the lens distortion is highest
-    in the corners of images.
-
-    Args:
-        region_detection_sets (Union[List[RegionDetectionSet], List[PATH_TYPE]])
-            Each element is a RegionDetectionsSet derived from a specific drone image,
-            or a geospatial file containing the detections from a drone image.
-            Length is the number of raw drone images given to  the dataloader.
-        ellipse (np.ndarray)
-            Mask of shape (height, width), dtype bool. The center of the ellipse
-            should be True, indicating those are the detections we wish to keep.
-            In order to be effective, this should be the same size as the images
-            the detections were created from.
-        threshold (float)
-            If the overlap of a given detection polygon with "valid" portions of the
-            mask is greater than the threshold, keep that detection. If not, filter
-            it out. Defaults to 0.4.
-
-    Returns:
-        List of RegiondetectionSet objects with masked predictions filtered out (one per
-        image) OR list of geospatial dataframes (one per image). This is based on the
-        input type of region_detection_sets
-    """
-
-    filtered_sets = []
-
-    # Iterate over the RegionDetectionsSet objects
-    for rds in region_detection_sets:
-
-        # Define a transformation from the image space ([0, 0] at the top left,
-        # y increases going down) to rasterstats ([0, 0] at the bottom left,
-        # y increases going up)
-        # See Affine comment in remove_masked_detections for more details.
-        transform = Affine.translation(0, mask.shape[0]) * Affine.scale(1, -1)
-
-        # To save filtered region detections in a particular set
-        filtered_regions = []
-
-        # We should either have a RegionDetectionsSet class, or a file path
-        # to a dataframe containing the detections
-        if isinstance(rds, RegionDetectionsSet):
-
-            def iterator(rds):
-                for idx in range(len(rds.region_detections)):
-                    rd = rds.get_region_detections(idx)
-                    yield idx, rd.get_data_frame()
-
-        else:
-
-            def iterator(rds):
-                yield 0, gpd.read_file(rds)
-
-        # Iterate over the region detections, which is equivalent to iterating
-        # over the chips that detections were calculated in
-        for idx, gdf in iterator(rds):
-
-            # Get the mean value of each detection polygon, as a list of
-            # [{"mean": <value>}, ...]
+            # Make the mask integer so that we can do math on the detections.
+            # For example, if a detection is 50+% valid, the mean value within
+            # the polygon will be 0.5+ because the mask is in numbers.
             stats = rasterstats.zonal_stats(
                 gdf, mask.astype(int)[::-1, ...], stats=["mean"], affine=transform
             )

--- a/tree_detection_framework/postprocessing/postprocessing.py
+++ b/tree_detection_framework/postprocessing/postprocessing.py
@@ -2,17 +2,17 @@ import logging
 from pathlib import Path
 from typing import List, Optional, Union
 
-import geopandas as gpd
 import numpy as np
-import rasterstats
-from affine import Affine
-from geopandas import GeoDataFrame
 from PIL import Image
-from polygone_nms import nms
 from shapely import box
 from shapely.geometry import MultiPolygon, Polygon
 from shapely.ops import unary_union
 
+import geopandas as gpd
+import rasterstats
+from affine import Affine
+from geopandas import GeoDataFrame
+from polygone_nms import nms
 from tree_detection_framework.constants import PATH_TYPE
 from tree_detection_framework.detection.region_detections import (
     RegionDetections,
@@ -178,8 +178,7 @@ def update_gdf_to_centroid(gdf: GeoDataFrame) -> GeoDataFrame:
 
 
 def NMS_on_points(
-    detections: Union[RegionDetections, RegionDetectionsSet],
-    threshold_distance: float,
+    detections: Union[RegionDetections, RegionDetectionsSet], threshold_distance: float
 ) -> RegionDetections:
     """
     Run non-max suppression on point data, suppressing points within a thereshold distance of
@@ -295,9 +294,7 @@ def single_region_hole_suppression(
     # Return a new RegionDetections object created using the updated dataframe
     # TODO: Handle cases where the data is in pixels with no transform to geospatial
     return RegionDetections(
-        detection_geometries=None,
-        data=detections_df,
-        CRS=detections.get_CRS(),
+        detection_geometries=None, data=detections_df, CRS=detections.get_CRS()
     )
 
 
@@ -661,10 +658,104 @@ def remove_masked_detections(
             # Get the mean value of each detection polygon, as a list of
             # [{"mean": <value>}, ...]
             stats = rasterstats.zonal_stats(
-                gdf,
-                mask.astype(int)[::-1, ...],
-                stats=["mean"],
-                affine=transform,
+                gdf, mask.astype(int)[::-1, ...], stats=["mean"], affine=transform
+            )
+
+            # Get indices that have a greater fraction of good pixels than the
+            # threshold requires.
+            good_indices = [
+                i for i, stat in enumerate(stats) if stat["mean"] > threshold
+            ]
+
+            if isinstance(rds, RegionDetectionsSet):
+                # Subset the RegionDetections object keeping only the valid indices
+                rd = rds.get_region_detections(idx)
+                filtered_rd = rd.subset_detections(good_indices)
+                filtered_regions.append(filtered_rd)
+            else:
+                # Take a subset of the dataframe rows that we know are valid
+                filtered_regions.append(gdf.iloc[good_indices])
+
+        if isinstance(rds, RegionDetectionsSet):
+            # If we were passed a list of RegionDetectionsSet items, then we want
+            # to recreate that for the output with filtered RDS items
+            filtered_sets.append(RegionDetectionsSet(filtered_regions))
+        else:
+            # Otherwise, if we were passed a list of GDF paths, return a list
+            # of filtered GDF items
+            filtered_sets.extend(filtered_regions)
+
+    return filtered_sets
+
+
+def viewpoint_ellipse_suppression(
+    region_detection_sets: Union[List[RegionDetectionsSet], List[PATH_TYPE]],
+    ellipse: np.ndarray,
+    threshold: float = 0.4,
+) -> List[RegionDetectionsSet]:
+    """
+    Filters out detections that marked as invalid in the given ellipse mask.
+    In general it could be useful to limit detections to the center of the
+    image when high accuracy is required because the lens distortion is highest
+    in the corners of images.
+
+    Args:
+        region_detection_sets (Union[List[RegionDetectionSet], List[PATH_TYPE]])
+            Each element is a RegionDetectionsSet derived from a specific drone image,
+            or a geospatial file containing the detections from a drone image.
+            Length is the number of raw drone images given to  the dataloader.
+        ellipse (np.ndarray)
+            Mask of shape (height, width), dtype bool. The center of the ellipse
+            should be True, indicating those are the detections we wish to keep.
+            In order to be effective, this should be the same size as the images
+            the detections were created from.
+        threshold (float)
+            If the overlap of a given detection polygon with "valid" portions of the
+            mask is greater than the threshold, keep that detection. If not, filter
+            it out. Defaults to 0.4.
+
+    Returns:
+        List of RegiondetectionSet objects with masked predictions filtered out (one per
+        image) OR list of geospatial dataframes (one per image). This is based on the
+        input type of region_detection_sets
+    """
+
+    filtered_sets = []
+
+    # Iterate over the RegionDetectionsSet objects
+    for rds in region_detection_sets:
+
+        # Define a transformation from the image space ([0, 0] at the top left,
+        # y increases going down) to rasterstats ([0, 0] at the bottom left,
+        # y increases going up)
+        # See Affine comment in remove_masked_detections for more details.
+        transform = Affine.translation(0, mask.shape[0]) * Affine.scale(1, -1)
+
+        # To save filtered region detections in a particular set
+        filtered_regions = []
+
+        # We should either have a RegionDetectionsSet class, or a file path
+        # to a dataframe containing the detections
+        if isinstance(rds, RegionDetectionsSet):
+
+            def iterator(rds):
+                for idx in range(len(rds.region_detections)):
+                    rd = rds.get_region_detections(idx)
+                    yield idx, rd.get_data_frame()
+
+        else:
+
+            def iterator(rds):
+                yield 0, gpd.read_file(rds)
+
+        # Iterate over the region detections, which is equivalent to iterating
+        # over the chips that detections were calculated in
+        for idx, gdf in iterator(rds):
+
+            # Get the mean value of each detection polygon, as a list of
+            # [{"mean": <value>}, ...]
+            stats = rasterstats.zonal_stats(
+                gdf, mask.astype(int)[::-1, ...], stats=["mean"], affine=transform
             )
 
             # Get indices that have a greater fraction of good pixels than the

--- a/tree_detection_framework/utils/geometric.py
+++ b/tree_detection_framework/utils/geometric.py
@@ -3,7 +3,6 @@ from typing import Tuple
 import cv2
 import numpy as np
 import shapely
-
 from contourpy import contour_generator
 
 
@@ -118,8 +117,8 @@ def ellipse_mask(
         axes (Tuple[int, int]):
             (a, b) semi-major and semi-minor axis lengths in pixels
         angle_rad (float):
-            Rotation angle of the semi-major axis, in radians. CCW from x-axis.
-            Defaults to 0.
+            Rotation angle of the semi-major axis, in radians. CCW from x-axis
+            (a.k.a. right-hand rule out of the image). Defaults to 0.
 
     Returns:
         mask: np.ndarray of shape (H, W), dtype=bool
@@ -128,7 +127,10 @@ def ellipse_mask(
     y, x = np.ogrid[:H, :W]
     x0, y0 = center
     a, b = axes
-    cos_t, sin_t = np.cos(angle_rad), np.sin(angle_rad)
+    # We need to invert the angle because images have Y pointing down
+    # (left-hand reference frame) but for ease of use we are going to
+    # specify the angle as if Y was up as the docstring describes.
+    cos_t, sin_t = np.cos(-angle_rad), np.sin(-angle_rad)
 
     # Shift and rotate the coordinates
     x_shift = x - x0


### PR DESCRIPTION
In some cases I think it might be helpful to mask out an image with an ellipse to avoid high distortion edges, I was thinking about changing:

BEFORE
* `remove_masked_detections` would read image mask files and apply them to region detections
AFTER
* Now there is a general purpose function `remove_masked_detections` that accepts a mask as a numpy array and applies them to region detections
* Now `remove_maskfile_detections` just reads the image mask files and calls `remove_masked_detections` using what it reads

Let me know if this doesn't seem necessary, my thought is that it is an easy way to not have to deal with distortion more fully and correctly for now. The new `remove_masked_detections` function also takes arbitrary masks if people have other masks they want to apply over the detections.

Here's an example of an ellipse that might be applied (the dark area):

<img width="730" height="549" alt="image" src="https://github.com/user-attachments/assets/f1382083-5b54-42ea-9118-f7972a581bd4" />


