### PR TITLE
Add default column names for watershed method

### DIFF
--- a/tree_detection_framework/detection/detector.py
+++ b/tree_detection_framework/detection/detector.py
@@ -797,7 +797,9 @@ class GeometricTreeCrownDetector(Detector):
             crowns.append(data_dict)
 
         # Create a gdf for the output
-        crown_gdf = gpd.GeoDataFrame(crowns, geometry="tree_crown")
+        crown_gdf = gpd.GeoDataFrame(
+            crowns, geometry="tree_crown", columns=["tree_crown", "treetop_height"]
+        )
         # Simplify by tolerance value to get smoother crown polygons
         crown_gdf["tree_crown"] = crown_gdf["tree_crown"].simplify(
             tolerance=self.simplify_tolerance, preserve_topology=True


### PR DESCRIPTION
I was having an error with tiles that did not have any detections because the column names were not set and this [line](https://github.com/open-forest-observatory/tree-detection-framework/blob/d25223a5419773559475c621e4d290abd8300b4f/tree_detection_framework/detection/detector.py#L800) would fail because `tree_crown` wasn't present. I just added a `columns` attribute when constructing the data frame so columns are present even if there aren't any rows. I validated that this worked on the problematic dataset.