### PR TITLE
Feature/dr/add sequential geometric entrypoint

### DIFF
--- a/tree_detection_framework/entrypoints/detect_geometric_two_stage.py
+++ b/tree_detection_framework/entrypoints/detect_geometric_two_stage.py
@@ -139,13 +139,13 @@ def parse_args():
         help="Where to save the detected tree crowns.",
     )
     parser.add_argument(
-        "--chip_size",
+        "--chip-size",
         type=int,
         default=CHIP_SIZE,
         help=f"The size of the chip in pixels. Defaults to {CHIP_SIZE}.",
     )
     parser.add_argument(
-        "--chip_stride",
+        "--chip-stride",
         type=int,
         default=CHIP_STRIDE,
         help=f"The stride of the sliding chip window in pixels. Defaults to {CHIP_STRIDE}.",


### PR DESCRIPTION
This adds a two-stage tree detection approach, taken from the species prediction project [here](https://github.com/open-forest-observatory/tree-species-prediction/blob/21dbe71cde6c0c492b9654d8643343c9d014e4c7/1_data_prep/08_detect_trees.py#L1). This entrypoint is needed because there are considerations that are specific to first detecting tree tops and then performing segmentation which do not fit the paradigm of the existing [entrypoint](https://github.com/open-forest-observatory/tree-detection-framework/blob/33254fe53decf195f223fbff3b4b23435adaa531/tree_detection_framework/entrypoints/generate_predictions.py#L1). Specifically, it's important that tree top detections at tile bounds are suppressed, by excluding detections in the buffer region at the edge of the tiles. Then all the merged tree tops are given to the approach that performs segmentation.

The following tests were performed and worked correctly:
```
python tree_detection_framework/entrypoints/detect_geometric_two_stage.py data/emerald-point-chm/chm.tif /tmp/tree_tops.gpkg /tmp/tree_crowns.gpkg
python tree_detection_framework/entrypoints/detect_geometric_two_stage.py data/emerald-point-chm/chm.tif /ofo-share/scratch/david/tree_tops.gpkg /ofo-share/scratch/david/tree_crowns.gpkg --tree-top-detector-kwargs '{"b": 0.05, "c": 2}'
python tree_detection_framework/entrypoints/detect_geometric_two_stage.py data/emerald-point-chm/chm.tif /ofo-share/scratch/david/tree_tops.gpkg /ofo-share/scratch/david/tree_crowns.gpkg --tree-top-detector-kwargs '{"b": 0.05, "c": 2}' --chip-size 400 --chip-stride 300
```