### PR TITLE
Dockerfile updates to use GPU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
-# Base python image
-FROM python:3.10.19-slim
-# Install git, gcc/g++, and curl for downloading and compiling
+# CUDA base image
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+# Install Python, git, gcc/g++, and curl for downloading and compiling
 # Also install libgl1 and libglib2.0-0 for cv2/albumentations dependency
 RUN apt-get update && \
     apt-get install -y \
+    python3 \
+    python3-pip \
+    python3-dev \
     git \
     build-essential \
     curl \
     libgl1 \
     libglib2.0-0 && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
     rm -rf /var/lib/apt/lists/*
 # Install poetry
 RUN curl -sSL https://install.python-poetry.org | python3 -


### PR DESCRIPTION
Previously the base python image was `python:3.10.19-slim` which is CPU-only and not CUDA compatible (DeepForest didn't use GPUs when I initially tested). I changed it to `nvidia/cuda:12.2.0-runtime-ubuntu22.04` based on my NVIDIA driver version. Because of this change, I had to specify Python installation explicitly since CUDA base image does not include Python.

Testing
---
Built the new image 
`docker build -t tdf-deepforest-one .`

and ran the below command:
```
docker run --rm -it --gpus all \
  -v /ofo-share/repos/amritha/tree-detection-framework:/workspace \
  tdf-deepforest-one \
  python /app/tree_detection_framework/entrypoints/generate_predictions.py \
  --raster-folder-path /workspace/data/emerald-point-ortho \
  --chip-size 1000 \
  --chip-stride 700 \
  --tree-detection-model deepforest \
  --predictions-save-path /workspace/data/saved-gpkgs/test_container_output_df_gpu.gpkg
```

Results
---

- Ran DeepForest successfully inside Docker
- Outputs saved correctly
- GPU usage confirmed via:
    - `nvtop`
    - log message:  `GPU available: True (cuda), used: True` 
