### PR TITLE
Detectree2 installation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Finally, choose to either install the Detectron2 or SAM2 detection framework.
 The Detectron2 library is not compatible with `poetry` so must be installed directly with pip
 ```
 # https://detectron2.readthedocs.io/en/latest/tutorials/install.html#build-detectron2-from-source
-pip install git+https://github.com/facebookresearch/detectron2.git
+pip install --no-build-isolation git+https://github.com/facebookresearch/detectron2.git
 ```
 Download the detectree2 checkpoint weights.
 ```


### PR DESCRIPTION
Closes #171 

The issue was that `pip install` for detectron2 is running its build process in an isolated subprocess that doesn't inherit the  conda environment's installed packages (packages installed earlier via `poetry install`). Even though torch is installed in the env, the build subprocess can't see it.

The fix is to pass `--no-build-isolation` to pip, which tells it to use the current environment's packages during the build step rather than creating a fresh isolated environment.

I still don't know why it was working fine earlier when we set up Detectree2Detector.