### PR TITLE
Replace NMS with keeping central crowns in geometric detection

### DIFF
--- a/tree_detection_framework/detection/detector.py
+++ b/tree_detection_framework/detection/detector.py
@@ -804,7 +804,7 @@ class GeometricTreeCrownDetector(Detector):
         id_to_height = {
             int(uid): height for uid, height in zip(filtered_ids, filtered_heights)
         }
-        id_to_treetop_pixel_coord = {
+        id_to_treetop_pixel_coords = {
             int(uid): tpc for uid, tpc in zip(filtered_ids, filtered_points)
         }
 
@@ -816,14 +816,11 @@ class GeometricTreeCrownDetector(Detector):
         for geom, tree_id in shapes(labels.astype("int32"), mask=(labels > 0)):
             # Subtract one to account for the +1 offset when the mask was created.
             tree_id = int(tree_id) - 1
+            # Return the crown polygon, and height and location of the tree top
             data_dict = {
-                "tree_crown": shape(
-                    geom
-                ),  # return a shapely object with the coordinates
-                "treetop_height": id_to_height.get(
-                    tree_id
-                ),  # get height value corresponding to the treetop ID
-                "treetop_pixel_coords": id_to_treetop_pixel_coord.get(tree_id),
+                "tree_crown": shape(geom),
+                "treetop_height": id_to_height.get(tree_id),
+                "treetop_pixel_coords": id_to_treetop_pixel_coords.get(tree_id),
             }
             # Return treetop IDs only if they were separately detected
             if treetop_ids_provided:

--- a/tree_detection_framework/detection/detector.py
+++ b/tree_detection_framework/detection/detector.py
@@ -777,7 +777,7 @@ class GeometricTreeCrownDetector(Detector):
         ]
         if len(filtered) == 0:
             # Tile has no treetops above threshold. Return an empty GeoDataFrame.
-            columns = ["tree_crown", "treetop_height"]
+            columns = ["tree_crown", "treetop_height", "treetop_pixel_coords"]
             if treetop_ids_provided:
                 columns.append("treetop_unique_ID")
             empty_gdf = gpd.GeoDataFrame(columns=columns, geometry="tree_crown")
@@ -804,6 +804,9 @@ class GeometricTreeCrownDetector(Detector):
         id_to_height = {
             int(uid): height for uid, height in zip(filtered_ids, filtered_heights)
         }
+        id_to_treetop_pixel_coord = {
+            int(uid): tpc for uid, tpc in zip(filtered_ids, filtered_points)
+        }
 
         # Convert the labeled raster into polygon geometries using rasterio's shapes().
         # Each contiguous region of the same label value/crown ID is extracted as a polygon
@@ -820,6 +823,7 @@ class GeometricTreeCrownDetector(Detector):
                 "treetop_height": id_to_height.get(
                     tree_id
                 ),  # get height value corresponding to the treetop ID
+                "treetop_pixel_coords": id_to_treetop_pixel_coord.get(tree_id),
             }
             # Return treetop IDs only if they were separately detected
             if treetop_ids_provided:
@@ -830,7 +834,12 @@ class GeometricTreeCrownDetector(Detector):
         crown_gdf = gpd.GeoDataFrame(
             crowns,
             geometry="tree_crown",
-            columns=["tree_crown", "treetop_height", "treetop_unique_ID"],
+            columns=[
+                "tree_crown",
+                "treetop_height",
+                "treetop_unique_ID",
+                "treetop_pixel_coords",
+            ],
         )
 
         # Simplify by tolerance value to get smoother crown polygons

--- a/tree_detection_framework/entrypoints/detect_geometric_two_stage.py
+++ b/tree_detection_framework/entrypoints/detect_geometric_two_stage.py
@@ -95,18 +95,19 @@ def detect_trees_two_stage(
         # Create the crown detector, which is seeded by the tree top points detected in the last step
         # The score metric is how far from the edge the detection is, which prioritizes central detections
         treecrown_detector = GeometricTreeCrownDetector(
-            confidence_feature="distance", **crown_segmentation_kwargs
+            confidence_feature="distance",
+            **crown_segmentation_kwargs,
         )
 
         # Predict the crowns
         treecrown_detections = treecrown_detector.predict(raster_vector_dataloader)
-        # Suppress overlapping crown predictions. This step can be slow.
-        treecrown_detections = multi_region_NMS(
-            treecrown_detections,
-            confidence_column="score",
-            intersection_method="IOS",
-            run_per_region_NMS=False,
+        treecrown_detections_gdf = treecrown_detections.get_data_frame(merge=True)
+        treecrown_detections_gdf = treecrown_detections_gdf.sort_values(
+            "score", ascending=False
         )
+        treecrown_detections_gdf = treecrown_detections_gdf.groupby(
+            "treetop_unique_ID"
+        ).first()
 
     # Convert to the geodataframe representation
     treetop_detections_gdf = treetop_detections.get_data_frame(merge=True)
@@ -133,9 +134,6 @@ def detect_trees_two_stage(
     treetop_detections_gdf.to_file(tree_tops_save_path)
 
     if tree_crowns_save_path is not None:
-        # Convert to geodataframe representation
-        treecrown_detections_gdf = treecrown_detections.get_data_frame()
-
         # Drop the crowns corresponding to trees detected at the edge by ensuring crowns correspond
         # to a tree top which was kept
         if edge_suppression_meters is not None and edge_suppression_meters != 0:
@@ -144,7 +142,6 @@ def detect_trees_two_stage(
                     treetop_detections_gdf.unique_ID
                 )
             ]
-
         # Save the crowns
         tree_crowns_save_path.parent.mkdir(parents=True, exist_ok=True)
         treecrown_detections_gdf.to_file(tree_crowns_save_path)

--- a/tree_detection_framework/entrypoints/detect_geometric_two_stage.py
+++ b/tree_detection_framework/entrypoints/detect_geometric_two_stage.py
@@ -101,13 +101,23 @@ def detect_trees_two_stage(
 
         # Predict the crowns
         treecrown_detections = treecrown_detector.predict(raster_vector_dataloader)
+        # Convert to a data frame
         treecrown_detections_gdf = treecrown_detections.get_data_frame(merge=True)
+        # Rank the detections so the ones which have a tree top closer to the center of their
+        # respective tile are first
         treecrown_detections_gdf = treecrown_detections_gdf.sort_values(
             "score", ascending=False
         )
+        # The CRS is dropped by the next step
+        crown_CRS = treecrown_detections_gdf.crs
+
+        # Take one crown per tree top, prefering the crowns where the corresponding tree top was
+        # closer to the center.
         treecrown_detections_gdf = treecrown_detections_gdf.groupby(
-            "treetop_unique_ID"
+            "treetop_unique_ID", as_index=False
         ).first()
+        # Reset the CRS
+        treecrown_detections_gdf.set_crs(crown_CRS, inplace=True)
 
     # Convert to the geodataframe representation
     treetop_detections_gdf = treetop_detections.get_data_frame(merge=True)

--- a/tree_detection_framework/utils/detection.py
+++ b/tree_detection_framework/utils/detection.py
@@ -34,7 +34,6 @@ def calculate_scores(
         raise ValueError(
             "Invalid confidence_feature provided. Choose from: `height`, `area`, `distance`, `all`"
         )
-
     if confidence_feature == "height":
         # Use height values as scores
         confidence_scores = tile_gdf["treetop_height"]
@@ -48,10 +47,6 @@ def calculate_scores(
         confidence_scores = tile_gdf[geometry_column].apply(lambda geom: geom.area)
 
     elif confidence_feature == "distance":
-        # Calculate the centroid of each tree crown
-        tile_gdf["centroid"] = tile_gdf[geometry_column].apply(
-            lambda geom: geom.centroid if not geom.is_empty else None
-        )
 
         # Calculate distances to the closest edge for each centroid
         def calculate_edge_distance(centroid):
@@ -67,7 +62,19 @@ def calculate_scores(
             # Return the distance to the closest edge
             return min(distances)
 
-        tile_gdf["edge_distance"] = tile_gdf["centroid"].apply(calculate_edge_distance)
+        if "treetop_pixel_coords" in tile_gdf.columns:
+            tile_gdf["edge_distance"] = tile_gdf["treetop_pixel_coords"].apply(
+                calculate_edge_distance
+            )
+        else:
+            # If an explicit tree top is not provided, use the centroid
+            tile_gdf["centroid"] = tile_gdf[geometry_column].apply(
+                lambda geom: geom.centroid if not geom.is_empty else None
+            )
+            tile_gdf["edge_distance"] = tile_gdf["centroid"].apply(
+                calculate_edge_distance
+            )
+
         # Use edge distance values as scores
         confidence_scores = tile_gdf["edge_distance"]
 

--- a/tree_detection_framework/utils/detection.py
+++ b/tree_detection_framework/utils/detection.py
@@ -47,7 +47,6 @@ def calculate_scores(
         confidence_scores = tile_gdf[geometry_column].apply(lambda geom: geom.area)
 
     elif confidence_feature == "distance":
-
         # Calculate distances to the closest edge for each centroid
         def calculate_edge_distance(centroid):
             if centroid is None:  # Check if centroid is None (empty geometry case)
@@ -63,17 +62,16 @@ def calculate_scores(
             return min(distances)
 
         if "treetop_pixel_coords" in tile_gdf.columns:
+            # This represents the location of the treetop relative to the tile pixel coordinates
             tile_gdf["edge_distance"] = tile_gdf["treetop_pixel_coords"].apply(
                 calculate_edge_distance
             )
         else:
-            # If an explicit tree top is not provided, use the centroid
-            tile_gdf["centroid"] = tile_gdf[geometry_column].apply(
+            # If an explicit tree top is not provided, use the centroid of the crown
+            centroid = tile_gdf[geometry_column].apply(
                 lambda geom: geom.centroid if not geom.is_empty else None
             )
-            tile_gdf["edge_distance"] = tile_gdf["centroid"].apply(
-                calculate_edge_distance
-            )
+            tile_gdf["edge_distance"] = centroid.apply(calculate_edge_distance)
 
         # Use edge distance values as scores
         confidence_scores = tile_gdf["edge_distance"]

--- a/tree_detection_framework/utils/detection.py
+++ b/tree_detection_framework/utils/detection.py
@@ -47,11 +47,11 @@ def calculate_scores(
         confidence_scores = tile_gdf[geometry_column].apply(lambda geom: geom.area)
 
     elif confidence_feature == "distance":
-        # Calculate distances to the closest edge for each centroid
-        def calculate_edge_distance(centroid):
-            if centroid is None:  # Check if centroid is None (empty geometry case)
+        # Calculate distances to the closest edge for each point
+        def calculate_edge_distance(point):
+            if point is None:  # Check if point is None (empty geometry case)
                 return 0
-            x, y = centroid.x, centroid.y
+            x, y = point.x, point.y
             distances = [
                 x,  # left edge
                 image_shape[1] - x,  # right edge


### PR DESCRIPTION
This closes #175. It actually required only a small change to update the `distance` score to reflect the distance of the seed point, not the crown centroid. From there, NMS can be replaced by an approach that compares all crowns for a given tree top and retains the crown for which the tree top was farthest from the tile edge for the corresponding tile.