### PR TITLE
Retain crown for first (`00000`) treetop

### DIFF
--- a/tree_detection_framework/detection/detector.py
+++ b/tree_detection_framework/detection/detector.py
@@ -788,9 +788,11 @@ class GeometricTreeCrownDetector(Detector):
 
         # Rasterize treetops as markers
         markers = rasterize(
-            # Convert uid to int since it's a string with 0 padded values
-            [(pt, int(uid)) for pt, uid in zip(filtered_points, filtered_ids)],
+            # Convert uid to int since it's originally a string with 0 padded values
+            # Add 1 to the value because watershed expects the background to be represented by 0s
+            [(pt, int(uid) + 1) for pt, uid in zip(filtered_points, filtered_ids)],
             out_shape=image.shape,
+            fill=0,
         )
 
         # Invert the CHM so that high points (tree tops) become basins for watershed
@@ -809,7 +811,8 @@ class GeometricTreeCrownDetector(Detector):
         # `mask` ensures that only non-zero crown areas are included in the output.
         crowns = []
         for geom, tree_id in shapes(labels.astype("int32"), mask=(labels > 0)):
-            tree_id = int(tree_id)
+            # Subtract one to account for the +1 offset when the mask was created.
+            tree_id = int(tree_id) - 1
             data_dict = {
                 "tree_crown": shape(
                     geom


### PR DESCRIPTION
Closes #179 following @amrithasp02 's suggestion

I tested this on the example data with the following command on both `main` and this branch.
```
python tree_detection_framework/entrypoints/detect_geometric_two_stage.py \
data/emerald-point-chm/chm.tif scratch/missing-crown-polygons/tree-tops-main.gpkg \
--tree-crowns-save-path scratch/missing-crown-polygons/tree-crowns-main.gpkg \
--chip-size 1000 --chip-stride 900
```
This change correctly retained the crown for the treetop with ID `00000`. In both cases, three IDs ('00289', '01015', and '01413') did not have a crown. But I checked each of them and they correspond to tree tops that were short and on the "shoulder" of another tree, so it makes sense that no crown was identified.