### PR TITLE
Make nonoverlapping region computation work for single polygon

### DIFF
--- a/tree_detection_framework/utils/geometric.py
+++ b/tree_detection_framework/utils/geometric.py
@@ -148,12 +148,12 @@ def ellipse_mask(
     return mask.astype(bool)
 
 
-def ordered_voronoi(points):
+def ordered_voronoi(points, tolerance:float=1e-6):
     """
     The shapely version we are using does not order the voronoi polygons in the same way as the
     input points. This wrapper does that.
     """
-    voronoi = shapely.voronoi_polygons(points)
+    voronoi = shapely.voronoi_polygons(points, tolerance=tolerance)
 
     ordered_voronoi = []
 

--- a/tree_detection_framework/utils/geometric.py
+++ b/tree_detection_framework/utils/geometric.py
@@ -293,6 +293,10 @@ def make_polygon_set_nonoverlapping(
     Returns:
         List[shapely.geometry.polygon.Polygon]: The core regions, ordered the same way as the input
     """
+    # If there are zero or one polygons, just return that unchanged
+    if len(polygons) <= 1:
+        return polygons
+
     nonoverlapping_regions = defaultdict(list)
 
     for i, first_poly in enumerate(polygons):

--- a/tree_detection_framework/utils/geometric.py
+++ b/tree_detection_framework/utils/geometric.py
@@ -148,7 +148,7 @@ def ellipse_mask(
     return mask.astype(bool)
 
 
-def ordered_voronoi(points, tolerance:float=1e-6):
+def ordered_voronoi(points, tolerance: float = 1e-6):
     """
     The shapely version we are using does not order the voronoi polygons in the same way as the
     input points. This wrapper does that.


### PR DESCRIPTION
There was a bug in the nonoverlapping region computation that would produce a zero-length list if only one polygon was provided. This was because there were no pairwise comparisons, so the subsequent logic broke. This fix just returns the input one-length list unchanged. It doesn't really matter, but it similarly returns a zero-length list directly.

This issue can be seen where all detections will be suppressed if there's only one tile. The following command fails on `main` but works on this branch.
```
python tree_detection_framework/entrypoints/detect_geometric_two_stage.py data/emerald-point-chm/chm.tif \
  /tmp/tree-tops.gpkg --tree-crowns-save-path /tmp/crowns.gpkg --chip-size 4000 --chip-stride 3600 \
  --resolution 0.12 --raster-blur-sigma 0.333 --edge-suppression-meters 10
```