### PR TITLE
Dockerfile updates to support Detectree2, SAM2 and SAM3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,5 @@ data/
 sandbox/
 examples/
 checkpoints/
+!checkpoints/sam3.pt
 train_outputs/

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,4 @@ data/
 sandbox/
 examples/
 checkpoints/
-!checkpoints/sam3.pt
 train_outputs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,16 @@ RUN /root/.local/bin/poetry config virtualenvs.create false && \
 # subprocess can see torch already installed above by poetry
 RUN pip install --no-build-isolation git+https://github.com/facebookresearch/detectron2.git
 
-# Stage 2: runtime 
+# Install SAM2 from source
+RUN pip install --no-cache-dir git+https://github.com/facebookresearch/sam2.git
+
+# SAM3's __init__.py imports torch at module level, so the wheel build needs torch
+# available — use --no-build-isolation to share the current environment
+RUN pip install --no-build-isolation --no-cache-dir \
+    git+https://github.com/facebookresearch/sam3.git \
+    decord
+
+# Stage 2: runtime
 # No compilers, no build tools, no poetry — only what's needed to run.
 FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
 
@@ -38,15 +47,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=builder /usr/local/lib/python3.10 /usr/local/lib/python3.10
 COPY --from=builder /usr/local/bin /usr/local/bin
 
+
 # Source code is NOT baked in — mount the repo at /app at runtime.
 # PYTHONPATH lets Python find tree_detection_framework from the mounted volume.
 WORKDIR /app
 ENV PYTHONPATH=/app
 
-# Download the detectree2 weights
-RUN mkdir -p /app/checkpoints/detectree2 && \
-    curl -L -o /app/checkpoints/detectree2/230103_randresize_full.pth \
-    https://zenodo.org/records/10522461/files/230103_randresize_full.pth
+# Download detectree2 and SAM2 weights; copy locally-saved SAM3 weights
+RUN mkdir -p /app/checkpoints && \
+    curl -L -o /app/checkpoints/230103_randresize_full.pth \
+        https://zenodo.org/records/10522461/files/230103_randresize_full.pth && \
+    curl -L -o /app/checkpoints/sam2.1_hiera_large.pt \
+        https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_large.pt
+
+COPY checkpoints/sam3.pt /app/checkpoints/sam3.pt
 
 # Run the detector script
 CMD python /app/tree_detection_framework/entrypoints/generate_predictions.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,14 +53,13 @@ COPY --from=builder /app/tree_detection_framework /app/tree_detection_framework
 WORKDIR /app
 ENV PYTHONPATH=/app
 
-# Download detectree2 and SAM2 weights; copy locally-saved SAM3 weights
+# Download detectree2 and SAM2 weights; SAM3 weights must be mounted at runtime
+# (see --sam3-checkpoint-path or --sam3-huggingface-token arguments)
 RUN mkdir -p /app/checkpoints && \
     curl -L -o /app/checkpoints/230103_randresize_full.pth \
         https://zenodo.org/records/10522461/files/230103_randresize_full.pth && \
     curl -L -o /app/checkpoints/sam2.1_hiera_large.pt \
         https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_large.pt
-
-COPY checkpoints/sam3.pt /app/checkpoints/sam3.pt
 
 # Run the detector script
 CMD python /app/tree_detection_framework/entrypoints/generate_predictions.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,15 @@ COPY . /app
 # Install the module dependencies with poetry without creating a virtual environment
 RUN /root/.local/bin/poetry config virtualenvs.create false && /root/.local/bin/poetry install
 
-# Install deepforest dependencies
-#RUN pip install git+https://github.com/facebookresearch/detectron2.git
+# Install detectron2 from source with --no-build-isolation so the build
+# subprocess can see torch (already installed above by poetry)
+RUN pip install --no-build-isolation \
+    git+https://github.com/facebookresearch/detectron2.git
 
-# Download the weights
-#RUN mkdir /app/checkpoints/detectree2 -p && cd /app/checkpoints/detectree2 && curl https://zenodo.org/records/10522461/files/230103_randresize_full.pth
-
-# Note that it's worth trying to install SAM as well in the same container but I'm not sure it will work
+# Download the detectree2 weights
+RUN mkdir -p /app/checkpoints/detectree2 && \
+    curl -L -o /app/checkpoints/detectree2/230103_randresize_full.pth \
+    https://zenodo.org/records/10522461/files/230103_randresize_full.pth
 
 # Run the detector script
 CMD python /app/tree_detection_framework/entrypoints/generate_predictions.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -sSL https://install.python-poetry.org | python3 -
 WORKDIR /app
 COPY . /app
 
-# Install only production dependencies (skip dev group and the root package)
+# Install only production dependencies 
 # --no-root avoids baking in the source package so it can be mounted at runtime
 RUN /root/.local/bin/poetry config virtualenvs.create false && \
     /root/.local/bin/poetry install --without dev --no-root
@@ -26,8 +26,8 @@ RUN pip install --no-build-isolation git+https://github.com/facebookresearch/det
 # Install SAM2 from source
 RUN pip install --no-cache-dir git+https://github.com/facebookresearch/sam2.git
 
-# SAM3's __init__.py imports torch at module level, so the wheel build needs torch
-# available — use --no-build-isolation to share the current environment
+# Install SAM3 from source and pin to commit 86ed770 because the latest commit
+# as of 4/21/2026 raises RuntimeError: mat1 and mat2 must have the same dtype, but got BFloat16 and Float
 RUN pip install --no-build-isolation --no-cache-dir \
     git+https://github.com/facebookresearch/sam3.git@86ed770 \
     decord
@@ -47,9 +47,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=builder /usr/local/lib/python3.10 /usr/local/lib/python3.10
 COPY --from=builder /usr/local/bin /usr/local/bin
 
+# Copy the TDF source package
+COPY --from=builder /app/tree_detection_framework /app/tree_detection_framework
 
-# Source code is NOT baked in — mount the repo at /app at runtime.
-# PYTHONPATH lets Python find tree_detection_framework from the mounted volume.
 WORKDIR /app
 ENV PYTHONPATH=/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# This is a multi-stage build that keeps the final image size small by 
+# only copying runtime dependencies and source code into the final image.
+
 # Stage 1: builder
 # Build tools, compilers, and poetry are only needed here.
 FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,47 @@
-# CUDA base image
-FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
-# Install Python, git, gcc/g++, and curl for downloading and compiling
-# Also install libgl1 and libglib2.0-0 for cv2/albumentations dependency
-RUN apt-get update && \
-    apt-get install -y \
-    python3 \
-    python3-pip \
-    python3-dev \
-    git \
-    build-essential \
-    curl \
-    libgl1 \
-    libglib2.0-0 && \
+# Stage 1: builder
+# Build tools, compilers, and poetry are only needed here.
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-pip python3-dev \
+    git build-essential curl \
+    libgl1 libglib2.0-0 && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     rm -rf /var/lib/apt/lists/*
-# Install poetry
+
 RUN curl -sSL https://install.python-poetry.org | python3 -
 
-# Set the container workdir
 WORKDIR /app
-# Copy files from current directory into /app
 COPY . /app
 
-# Install the module dependencies with poetry without creating a virtual environment
-RUN /root/.local/bin/poetry config virtualenvs.create false && /root/.local/bin/poetry install
+# Install only production dependencies (skip dev group and the root package)
+# --no-root avoids baking in the source package so it can be mounted at runtime
+RUN /root/.local/bin/poetry config virtualenvs.create false && \
+    /root/.local/bin/poetry install --without dev --no-root
 
 # Install detectron2 from source with --no-build-isolation so the build
-# subprocess can see torch (already installed above by poetry)
-RUN pip install --no-build-isolation \
-    git+https://github.com/facebookresearch/detectron2.git
+# subprocess can see torch already installed above by poetry
+RUN pip install --no-build-isolation git+https://github.com/facebookresearch/detectron2.git
+
+# Stage 2: runtime 
+# No compilers, no build tools, no poetry — only what's needed to run.
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+
+# libgl1 and libglib2.0-0 are runtime deps for cv2/albumentations
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-pip \
+    curl libgl1 libglib2.0-0 && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy installed Python packages and entry-point scripts from builder
+COPY --from=builder /usr/local/lib/python3.10 /usr/local/lib/python3.10
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Source code is NOT baked in — mount the repo at /app at runtime.
+# PYTHONPATH lets Python find tree_detection_framework from the mounted volume.
+WORKDIR /app
+ENV PYTHONPATH=/app
 
 # Download the detectree2 weights
 RUN mkdir -p /app/checkpoints/detectree2 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN pip install --no-cache-dir git+https://github.com/facebookresearch/sam2.git
 # SAM3's __init__.py imports torch at module level, so the wheel build needs torch
 # available — use --no-build-isolation to share the current environment
 RUN pip install --no-build-isolation --no-cache-dir \
-    git+https://github.com/facebookresearch/sam3.git \
+    git+https://github.com/facebookresearch/sam3.git@86ed770 \
     decord
 
 # Stage 2: runtime

--- a/tree_detection_framework/detection/SAM3_detector.py
+++ b/tree_detection_framework/detection/SAM3_detector.py
@@ -36,11 +36,12 @@ class SAM3Detector(Detector):
         bpe_path=_SAM3_DEFAULT_BPE_PATH,
         text_prompt="tree",
         confidence_threshold=0.4,
+        checkpoint_path=None,
         huggingface_token=None,
         postprocessors=None,
     ):
         """
-        Create a SAM3 detector. This detector uses a test prompt "tree" to detect tree crowns.
+        Create a SAM3 detector. This detector uses a text prompt "tree" to detect tree crowns.
         Refer README for steps to generate a HuggingFace access token to download the weights.
 
         Args:
@@ -51,9 +52,12 @@ class SAM3Detector(Detector):
                 Defaults to "tree".
             confidence_threshold (float): Minimum confidence score for keeping a
                 predicted mask. Defaults to 0.4.
+            checkpoint_path (str, optional): Path to a local SAM3 checkpoint
+                file (.pt). When provided, weights are loaded from disk and
+                HuggingFace download is skipped.
             huggingface_token (str, optional): HuggingFace API token for downloading
-                SAM3 model weights. Can also be set via the HF_TOKEN environment
-                variable. If neither is provided, assumes weights are already cached.
+                SAM3 model weights. Only used when checkpoint_path is not given.
+                Can also be set via the HF_TOKEN environment variable.
             postprocessors (list, optional): See docstring for Detector class.
                 Defaults to None.
         """
@@ -67,19 +71,26 @@ class SAM3Detector(Detector):
         self.text_prompt = text_prompt
         self.confidence_threshold = confidence_threshold
 
-        # Resolve HuggingFace token
-        token = huggingface_token or os.environ.get("HF_TOKEN")
-        if token:
-            from huggingface_hub import login
-
-            login(token=token)
-        else:
-            logging.info(
-                "No HuggingFace token provided. Assuming SAM3 weights are already cached. "
-                "Pass huggingface_token= or set the HF_TOKEN environment variable if download is needed."
+        if checkpoint_path is not None:
+            # Load weights from a local file; skip HuggingFace entirely.
+            self.model = build_sam3_image_model(
+                bpe_path=str(bpe_path),
+                checkpoint_path=str(checkpoint_path),
+                load_from_HF=False,
             )
+        else:
+            # Fall back to HuggingFace download path.
+            token = huggingface_token or os.environ.get("HF_TOKEN")
+            if token:
+                from huggingface_hub import login
 
-        self.model = build_sam3_image_model(bpe_path=str(bpe_path))
+                login(token=token)
+            else:
+                logging.info(
+                    "No HuggingFace token provided. Assuming SAM3 weights are already cached. "
+                    "Pass huggingface_token= or set the HF_TOKEN environment variable if download is needed."
+                )
+            self.model = build_sam3_image_model(bpe_path=str(bpe_path))
         self.processor = Sam3Processor(
             self.model, confidence_threshold=self.confidence_threshold
         )

--- a/tree_detection_framework/entrypoints/generate_predictions.py
+++ b/tree_detection_framework/entrypoints/generate_predictions.py
@@ -1,18 +1,21 @@
 import argparse
 import json
 import logging
+from pathlib import Path
 from typing import Optional
 
 import pyproj
 import torch
 
-from tree_detection_framework.constants import BOUNDARY_TYPE, PATH_TYPE
+from tree_detection_framework.constants import BOUNDARY_TYPE, CHECKPOINTS_FOLDER, PATH_TYPE
 from tree_detection_framework.detection.detector import (
     DeepForestDetector,
     Detectree2Detector,
     GeometricDetector,
 )
 from tree_detection_framework.detection.models import DeepForestModule, Detectree2Module
+from tree_detection_framework.detection.SAM2_detector import SAMV2Detector
+from tree_detection_framework.detection.SAM3_detector import SAM3Detector
 from tree_detection_framework.postprocessing.postprocessing import multi_region_NMS
 from tree_detection_framework.preprocessing.preprocessing import create_dataloader
 
@@ -33,7 +36,11 @@ def generate_predictions(
     iou_threshold: Optional[float] = 0.3,
     min_confidence: Optional[float] = 0.3,
     batch_size: int = 1,
-    detectree2_weights_path: str = "",
+    detectree2_weights_path: PATH_TYPE = Path(CHECKPOINTS_FOLDER, "230103_randresize_full.pth"),
+    sam2_checkpoint: PATH_TYPE = Path(CHECKPOINTS_FOLDER, "sam2.1_hiera_large.pt"),
+    sam2_model_cfg: str = "configs/sam2.1/sam2.1_hiera_l.yaml",
+    sam3_checkpoint_path: PATH_TYPE = Path(CHECKPOINTS_FOLDER, "sam3.pt"),
+    sam3_huggingface_token: Optional[str] = None,
     detector_kwargs: dict = {},
 ):
     """
@@ -47,7 +54,7 @@ def generate_predictions(
             Stride of the chip. May be pixels or meters, based on `use_units_meters`. If used,
             `chip_overlap_percentage` should not be set. Defaults to None.
         tree_detection_model (str):
-            Selected model for detecting trees. One of "deepforest", "detectree2", or "geometric".
+            Selected model for detecting trees. One of "deepforest", "detectree2", "geometric", "sam2", or "sam3".
         chip_overlap_percentage (Optional[float], optional):
             Percent overlap of the chip from 0-100. If used, `chip_stride` should not be set.
             Defaults to None.
@@ -74,8 +81,16 @@ def generate_predictions(
             Prediction score threshold for detections to be included.
         batch_size (int, optional):
             Number of images to load in a batch. Defaults to 1.
+        sam2_checkpoint (PATH_TYPE, optional):
+            Path to the SAM2 checkpoint file. Defaults to checkpoints/sam2.1_hiera_large.pt.
+        sam2_model_cfg (str, optional):
+            Path to the SAM2 model config yaml. Defaults to configs/sam2.1/sam2.1_hiera_l.yaml.
+        sam3_checkpoint_path (PATH_TYPE, optional):
+            Path to a local SAM3 checkpoint file. Defaults to checkpoints/sam3.pt.
+        sam3_huggingface_token (str, optional):
+            HuggingFace token for downloading SAM3 weights. Only used when sam3_checkpoint_path is None.
         detector_kwargs (dict, optional):
-            Optional keywork arguments to be unpacked for the detector constructor.
+            Optional keyword arguments to be unpacked for the detector constructor.
     """
 
     # Create the dataloader by passing folder path to raster data.
@@ -109,8 +124,7 @@ def generate_predictions(
 
     elif tree_detection_model == "detectree2":
 
-        trained_model = args.detectree2_weights_path
-        param_dict = {"update_model": trained_model}
+        param_dict = {"update_model": detectree2_weights_path}
 
         dtree2_module = Detectree2Module(param_dict)
         detector = Detectree2Detector(dtree2_module, **detector_kwargs)
@@ -119,12 +133,29 @@ def generate_predictions(
         # Create a geometric detector which is applicable to CHM inputs using the default parameters
         detector = GeometricDetector(**detector_kwargs)
 
+    elif tree_detection_model == "sam2":
+        detector = SAMV2Detector(
+            sam2_checkpoint=sam2_checkpoint,
+            model_cfg=sam2_model_cfg,
+            **detector_kwargs,
+        )
+
+    elif tree_detection_model == "sam3":
+        detector = SAM3Detector(
+            checkpoint_path=sam3_checkpoint_path,
+            huggingface_token=sam3_huggingface_token,
+            confidence_threshold=min_confidence,
+            **detector_kwargs,
+        )
+
     else:
         raise ValueError(
             """Please enter a valid tree detection model. Currently supported models are:
                 1. deepforest
                 2. detectree2
                 3. geometric
+                4. sam2
+                5. sam3
                 """
         )
 
@@ -180,8 +211,32 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--detectree2-weights-path",
         type=str,
-        default="/app/checkpoints/detectree2/230103_randresize_full.pth",
+        default=str(Path(CHECKPOINTS_FOLDER, "230103_randresize_full.pth")),
         help="Path to the detectree2 pretrained weights (.pth file)",
+    )
+    parser.add_argument(
+        "--sam2-checkpoint",
+        type=str,
+        default=str(Path(CHECKPOINTS_FOLDER, "sam2.1_hiera_large.pt")),
+        help="Path to the SAM2 checkpoint file",
+    )
+    parser.add_argument(
+        "--sam2-model-cfg",
+        type=str,
+        default="configs/sam2.1/sam2.1_hiera_l.yaml",
+        help="Path to the SAM2 model config yaml",
+    )
+    parser.add_argument(
+        "--sam3-checkpoint-path",
+        type=str,
+        default=str(Path(CHECKPOINTS_FOLDER, "sam3.pt")),
+        help="Path to a local SAM3 checkpoint file",
+    )
+    parser.add_argument(
+        "--sam3-huggingface-token",
+        type=str,
+        default=None,
+        help="HuggingFace token for downloading SAM3 weights (only used when --sam3-checkpoint-path is not set)",
     )
     parser.add_argument(
         "--detector-kwargs",

--- a/tree_detection_framework/entrypoints/generate_predictions.py
+++ b/tree_detection_framework/entrypoints/generate_predictions.py
@@ -229,7 +229,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--sam3-checkpoint-path",
         type=str,
-        default=str(Path(CHECKPOINTS_FOLDER, "sam3.pt")),
+        default=None,
         help="Path to a local SAM3 checkpoint file",
     )
     parser.add_argument(

--- a/tree_detection_framework/entrypoints/generate_predictions.py
+++ b/tree_detection_framework/entrypoints/generate_predictions.py
@@ -7,7 +7,11 @@ from typing import Optional
 import pyproj
 import torch
 
-from tree_detection_framework.constants import BOUNDARY_TYPE, CHECKPOINTS_FOLDER, PATH_TYPE
+from tree_detection_framework.constants import (
+    BOUNDARY_TYPE,
+    CHECKPOINTS_FOLDER,
+    PATH_TYPE,
+)
 from tree_detection_framework.detection.detector import (
     DeepForestDetector,
     Detectree2Detector,

--- a/tree_detection_framework/entrypoints/generate_predictions.py
+++ b/tree_detection_framework/entrypoints/generate_predictions.py
@@ -11,7 +11,6 @@ from tree_detection_framework.constants import BOUNDARY_TYPE, CHECKPOINTS_FOLDER
 from tree_detection_framework.detection.detector import (
     DeepForestDetector,
     Detectree2Detector,
-    GeometricDetector,
 )
 from tree_detection_framework.detection.models import DeepForestModule, Detectree2Module
 from tree_detection_framework.detection.SAM2_detector import SAMV2Detector
@@ -54,7 +53,7 @@ def generate_predictions(
             Stride of the chip. May be pixels or meters, based on `use_units_meters`. If used,
             `chip_overlap_percentage` should not be set. Defaults to None.
         tree_detection_model (str):
-            Selected model for detecting trees. One of "deepforest", "detectree2", "geometric", "sam2", or "sam3".
+            Selected model for detecting trees. One of "deepforest", "detectree2", "sam2", or "sam3".
         chip_overlap_percentage (Optional[float], optional):
             Percent overlap of the chip from 0-100. If used, `chip_stride` should not be set.
             Defaults to None.
@@ -129,10 +128,6 @@ def generate_predictions(
         dtree2_module = Detectree2Module(param_dict)
         detector = Detectree2Detector(dtree2_module, **detector_kwargs)
 
-    elif tree_detection_model == "geometric":
-        # Create a geometric detector which is applicable to CHM inputs using the default parameters
-        detector = GeometricDetector(**detector_kwargs)
-
     elif tree_detection_model == "sam2":
         detector = SAMV2Detector(
             sam2_checkpoint=sam2_checkpoint,
@@ -153,9 +148,8 @@ def generate_predictions(
             """Please enter a valid tree detection model. Currently supported models are:
                 1. deepforest
                 2. detectree2
-                3. geometric
-                4. sam2
-                5. sam3
+                3. sam2
+                4. sam3
                 """
         )
 

--- a/tree_detection_framework/entrypoints/generate_predictions.py
+++ b/tree_detection_framework/entrypoints/generate_predictions.py
@@ -33,6 +33,7 @@ def generate_predictions(
     iou_threshold: Optional[float] = 0.3,
     min_confidence: Optional[float] = 0.3,
     batch_size: int = 1,
+    detectree2_weights_path: str = "",
     detector_kwargs: dict = {},
 ):
     """
@@ -108,11 +109,7 @@ def generate_predictions(
 
     elif tree_detection_model == "detectree2":
 
-        # Load detectree2 pretrained weights
-        # TODO: download pretrained weights when called, instead of providing a local path
-        trained_model = (
-            "/ofo-share/repos-amritha/detectree2-code/230103_randresize_full.pth"
-        )
+        trained_model = args.detectree2_weights_path
         param_dict = {"update_model": trained_model}
 
         dtree2_module = Detectree2Module(param_dict)
@@ -180,6 +177,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--iou-threshold", type=float, default=0.3)
     parser.add_argument("--min-confidence", type=float, default=0.3)
     parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument(
+        "--detectree2-weights-path",
+        type=str,
+        default="/app/checkpoints/detectree2/230103_randresize_full.pth",
+        help="Path to the detectree2 pretrained weights (.pth file)",
+    )
     parser.add_argument(
         "--detector-kwargs",
         type=str,

--- a/tree_detection_framework/entrypoints/generate_predictions.py
+++ b/tree_detection_framework/entrypoints/generate_predictions.py
@@ -42,8 +42,7 @@ def generate_predictions(
     detectree2_weights_path: PATH_TYPE = Path(
         CHECKPOINTS_FOLDER, "230103_randresize_full.pth"
     ),
-    sam2_checkpoint: PATH_TYPE = Path(CHECKPOINTS_FOLDER, "sam2.1_hiera_large.pt"),
-    sam2_model_cfg: str = "configs/sam2.1/sam2.1_hiera_l.yaml",
+    sam2_checkpoint_path: PATH_TYPE = Path(CHECKPOINTS_FOLDER, "sam2.1_hiera_large.pt"),
     sam3_checkpoint_path: PATH_TYPE = Path(CHECKPOINTS_FOLDER, "sam3.pt"),
     sam3_huggingface_token: Optional[str] = None,
     detector_kwargs: dict = {},
@@ -86,10 +85,8 @@ def generate_predictions(
             Prediction score threshold for detections to be included.
         batch_size (int, optional):
             Number of images to load in a batch. Defaults to 1.
-        sam2_checkpoint (PATH_TYPE, optional):
+        sam2_checkpoint_path (PATH_TYPE, optional):
             Path to the SAM2 checkpoint file. Defaults to checkpoints/sam2.1_hiera_large.pt.
-        sam2_model_cfg (str, optional):
-            Path to the SAM2 model config yaml. Defaults to configs/sam2.1/sam2.1_hiera_l.yaml.
         sam3_checkpoint_path (PATH_TYPE, optional):
             Path to a local SAM3 checkpoint file. Defaults to checkpoints/sam3.pt.
         sam3_huggingface_token (str, optional):
@@ -136,8 +133,7 @@ def generate_predictions(
 
     elif tree_detection_model == "sam2":
         detector = SAMV2Detector(
-            sam2_checkpoint=sam2_checkpoint,
-            model_cfg=sam2_model_cfg,
+            sam2_checkpoint=sam2_checkpoint_path,
             **detector_kwargs,
         )
 
@@ -215,16 +211,10 @@ def parse_args() -> argparse.Namespace:
         help="Path to the detectree2 pretrained weights (.pth file)",
     )
     parser.add_argument(
-        "--sam2-checkpoint",
+        "--sam2-checkpoint-path",
         type=str,
         default=str(Path(CHECKPOINTS_FOLDER, "sam2.1_hiera_large.pt")),
         help="Path to the SAM2 checkpoint file",
-    )
-    parser.add_argument(
-        "--sam2-model-cfg",
-        type=str,
-        default="configs/sam2.1/sam2.1_hiera_l.yaml",
-        help="Path to the SAM2 model config yaml",
     )
     parser.add_argument(
         "--sam3-checkpoint-path",

--- a/tree_detection_framework/entrypoints/generate_predictions.py
+++ b/tree_detection_framework/entrypoints/generate_predictions.py
@@ -39,7 +39,9 @@ def generate_predictions(
     iou_threshold: Optional[float] = 0.3,
     min_confidence: Optional[float] = 0.3,
     batch_size: int = 1,
-    detectree2_weights_path: PATH_TYPE = Path(CHECKPOINTS_FOLDER, "230103_randresize_full.pth"),
+    detectree2_weights_path: PATH_TYPE = Path(
+        CHECKPOINTS_FOLDER, "230103_randresize_full.pth"
+    ),
     sam2_checkpoint: PATH_TYPE = Path(CHECKPOINTS_FOLDER, "sam2.1_hiera_large.pt"),
     sam2_model_cfg: str = "configs/sam2.1/sam2.1_hiera_l.yaml",
     sam3_checkpoint_path: PATH_TYPE = Path(CHECKPOINTS_FOLDER, "sam3.pt"),


### PR DESCRIPTION
This PR makes the following changes:

1. Dockerfile does a multi-stage build to get an image of reasonable size (13.9 GB. Without the multi-stage it is >30GB)
2. Set up all the CV-based detectors (in additon to DeepForest): Detectree2, SAM2 and SAM3 
3. In `generate_predictions.py` I added support for SAM2 and SAM3. I removed `GeometricDetector` from it so that this entrypoint can be exclusively for CV-based detectors. We decided that for GeometricDetector we will use the 2-stage detector entrypoint [here](https://github.com/open-forest-observatory/tree-detection-framework/blob/main/tree_detection_framework/entrypoints/detect_geometric_two_stage.py).
4. SAM3 model weights have been moved to my /checkpoints folder in my TDF repository. This Dockerfile however, bakes in these weights (similar to the other detectors). I figured for our OFO use this is fine for now. In the future we will have to somehow support huggingface authentication to download SAM3 weights.
5. SAM3 codebase has been pinned to commit 86ed770 since this is the working version as per [this issue](https://github.com/facebookresearch/sam3/issues/507#issuecomment-4181589898)