### PR TITLE
Save all detections in the same layer - RegionDetectionsSet

### DIFF
--- a/sandbox/detection/save_multi_layer_detections_file.ipynb
+++ b/sandbox/detection/save_multi_layer_detections_file.ipynb
@@ -11,10 +11,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 1,
    "id": "d3c80ed6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/ofo-share/repos/amritha/conda/envs/tdf-dtree2/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "/ofo-share/repos/amritha/conda/envs/tdf-dtree2/lib/python3.10/site-packages/albumentations/__init__.py:28: UserWarning: A new version of Albumentations is available: '2.0.8' (you have '2.0.2'). Upgrade using: pip install -U albumentations. To disable automatic update checks, set the environment variable NO_ALBUMENTATIONS_UPDATE to 1.\n",
+      "  check_for_updates()\n"
+     ]
+    }
+   ],
    "source": [
     "from tree_detection_framework.preprocessing.preprocessing import (\n",
     "    create_dataloader,\n",
@@ -56,7 +67,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Performing prediction on batches: 100%|██████████| 6/6 [00:14<00:00,  2.35s/it]\n"
+      "Performing prediction on batches: 100%|██████████| 6/6 [00:13<00:00,  2.32s/it]\n"
      ]
     }
    ],
@@ -122,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 6,
    "id": "0d027d0c",
    "metadata": {},
    "outputs": [
@@ -130,28 +141,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pyogrio._io:Created 127 records\n",
-      "INFO:pyogrio._io:Created 169 records\n"
+      "INFO:pyogrio._io:Created 1,865 records\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pyogrio._io:Created 98 records\n",
-      "INFO:pyogrio._io:Created 30 records\n",
-      "INFO:pyogrio._io:Created 118 records\n",
-      "INFO:pyogrio._io:Created 181 records\n",
-      "INFO:pyogrio._io:Created 116 records\n",
-      "INFO:pyogrio._io:Created 16 records\n",
-      "INFO:pyogrio._io:Created 221 records\n",
-      "INFO:pyogrio._io:Created 211 records\n",
-      "INFO:pyogrio._io:Created 175 records\n",
-      "INFO:pyogrio._io:Created 29 records\n",
-      "INFO:pyogrio._io:Created 112 records\n",
-      "INFO:pyogrio._io:Created 109 records\n",
-      "INFO:pyogrio._io:Created 126 records\n",
-      "INFO:pyogrio._io:Created 27 records\n",
       "INFO:pyogrio._io:Created 16 records\n"
      ]
     }
@@ -174,33 +170,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 7,
    "id": "e4aa130e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['detections_0',\n",
-       " 'detections_1',\n",
-       " 'detections_2',\n",
-       " 'detections_3',\n",
-       " 'detections_4',\n",
-       " 'detections_5',\n",
-       " 'detections_6',\n",
-       " 'detections_7',\n",
-       " 'detections_8',\n",
-       " 'detections_9',\n",
-       " 'detections_10',\n",
-       " 'detections_11',\n",
-       " 'detections_12',\n",
-       " 'detections_13',\n",
-       " 'detections_14',\n",
-       " 'detections_15',\n",
-       " '_bounds']"
+       "['detections', 'bounds']"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -212,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "6d3fcb6d",
    "metadata": {},
    "outputs": [
@@ -238,6 +218,7 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>score</th>\n",
+       "      <th>region_ID</th>\n",
        "      <th>geometry</th>\n",
        "    </tr>\n",
        "  </thead>\n",
@@ -245,93 +226,104 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>POLYGON ((752262.09 4317061.699, 752262.09 431...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>POLYGON ((752266.29 4317061.699, 752266.89 431...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>7.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>POLYGON ((752262.89 4317061.699, 752264.09 431...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>7.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>POLYGON ((752282.49 4317061.699, 752282.09 431...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>POLYGON ((752317.69 4317061.699, 752318.89 431...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
+       "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>122</th>\n",
-       "      <td>62.0</td>\n",
-       "      <td>POLYGON ((752294.09 4316972.099, 752293.89 431...</td>\n",
+       "      <th>1860</th>\n",
+       "      <td>40.0</td>\n",
+       "      <td>15</td>\n",
+       "      <td>POLYGON ((752470.49 4317210.099, 752469.69 431...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>123</th>\n",
-       "      <td>39.0</td>\n",
-       "      <td>POLYGON ((752316.89 4316978.899, 752315.29 431...</td>\n",
+       "      <th>1861</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>15</td>\n",
+       "      <td>POLYGON ((752462.89 4317202.699, 752461.49 431...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>124</th>\n",
-       "      <td>37.0</td>\n",
-       "      <td>POLYGON ((752228.69 4316979.299, 752228.89 431...</td>\n",
+       "      <th>1862</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>15</td>\n",
+       "      <td>POLYGON ((752464.89 4317200.299, 752464.89 431...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>125</th>\n",
-       "      <td>20.0</td>\n",
-       "      <td>POLYGON ((752235.29 4316965.099, 752234.09 431...</td>\n",
+       "      <th>1863</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>15</td>\n",
+       "      <td>POLYGON ((752476.29 4317201.099, 752475.29 431...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>126</th>\n",
-       "      <td>11.0</td>\n",
-       "      <td>POLYGON ((752305.49 4316963.099, 752304.49 431...</td>\n",
+       "      <th>1864</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>15</td>\n",
+       "      <td>POLYGON ((752466.69 4317199.699, 752466.49 431...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>127 rows × 2 columns</p>\n",
+       "<p>1865 rows × 3 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "     score                                           geometry\n",
-       "0      0.0  POLYGON ((752262.09 4317061.699, 752262.09 431...\n",
-       "1      0.0  POLYGON ((752266.29 4317061.699, 752266.89 431...\n",
-       "2      7.0  POLYGON ((752262.89 4317061.699, 752264.09 431...\n",
-       "3      7.0  POLYGON ((752282.49 4317061.699, 752282.09 431...\n",
-       "4      0.0  POLYGON ((752317.69 4317061.699, 752318.89 431...\n",
-       "..     ...                                                ...\n",
-       "122   62.0  POLYGON ((752294.09 4316972.099, 752293.89 431...\n",
-       "123   39.0  POLYGON ((752316.89 4316978.899, 752315.29 431...\n",
-       "124   37.0  POLYGON ((752228.69 4316979.299, 752228.89 431...\n",
-       "125   20.0  POLYGON ((752235.29 4316965.099, 752234.09 431...\n",
-       "126   11.0  POLYGON ((752305.49 4316963.099, 752304.49 431...\n",
+       "      score  region_ID                                           geometry\n",
+       "0       0.0          0  POLYGON ((752262.09 4317061.699, 752262.09 431...\n",
+       "1       0.0          0  POLYGON ((752266.29 4317061.699, 752266.89 431...\n",
+       "2       7.0          0  POLYGON ((752262.89 4317061.699, 752264.09 431...\n",
+       "3       7.0          0  POLYGON ((752282.49 4317061.699, 752282.09 431...\n",
+       "4       0.0          0  POLYGON ((752317.69 4317061.699, 752318.89 431...\n",
+       "...     ...        ...                                                ...\n",
+       "1860   40.0         15  POLYGON ((752470.49 4317210.099, 752469.69 431...\n",
+       "1861    1.0         15  POLYGON ((752462.89 4317202.699, 752461.49 431...\n",
+       "1862    1.0         15  POLYGON ((752464.89 4317200.299, 752464.89 431...\n",
+       "1863    1.0         15  POLYGON ((752476.29 4317201.099, 752475.29 431...\n",
+       "1864    1.0         15  POLYGON ((752466.69 4317199.699, 752466.49 431...\n",
        "\n",
-       "[127 rows x 2 columns]"
+       "[1865 rows x 3 columns]"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Read the saved gpkg file and display detections from tile 0\n",
-    "gpd.read_file(SAVE_PATH, layer=\"detections_0\")"
+    "gpd.read_file(SAVE_PATH, layer=\"detections\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 9,
    "id": "40e799d1",
    "metadata": {},
    "outputs": [
@@ -356,7 +348,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>tile_id</th>\n",
+       "      <th>region_ID</th>\n",
        "      <th>geometry</th>\n",
        "    </tr>\n",
        "  </thead>\n",
@@ -446,33 +438,33 @@
        "</div>"
       ],
       "text/plain": [
-       "    tile_id                                           geometry\n",
-       "0         0  POLYGON ((752323.89 4316959.299, 752323.89 431...\n",
-       "1         1  POLYGON ((752403.89 4316959.299, 752403.89 431...\n",
-       "2         2  POLYGON ((752483.89 4316959.299, 752483.89 431...\n",
-       "3         3  POLYGON ((752563.89 4316959.299, 752563.89 431...\n",
-       "4         4  POLYGON ((752323.89 4317039.299, 752323.89 431...\n",
-       "5         5  POLYGON ((752403.89 4317039.299, 752403.89 431...\n",
-       "6         6  POLYGON ((752483.89 4317039.299, 752483.89 431...\n",
-       "7         7  POLYGON ((752563.89 4317039.299, 752563.89 431...\n",
-       "8         8  POLYGON ((752323.89 4317119.299, 752323.89 431...\n",
-       "9         9  POLYGON ((752403.89 4317119.299, 752403.89 431...\n",
-       "10       10  POLYGON ((752483.89 4317119.299, 752483.89 431...\n",
-       "11       11  POLYGON ((752563.89 4317119.299, 752563.89 431...\n",
-       "12       12  POLYGON ((752323.89 4317199.299, 752323.89 431...\n",
-       "13       13  POLYGON ((752403.89 4317199.299, 752403.89 431...\n",
-       "14       14  POLYGON ((752483.89 4317199.299, 752483.89 431...\n",
-       "15       15  POLYGON ((752563.89 4317199.299, 752563.89 431..."
+       "    region_ID                                           geometry\n",
+       "0           0  POLYGON ((752323.89 4316959.299, 752323.89 431...\n",
+       "1           1  POLYGON ((752403.89 4316959.299, 752403.89 431...\n",
+       "2           2  POLYGON ((752483.89 4316959.299, 752483.89 431...\n",
+       "3           3  POLYGON ((752563.89 4316959.299, 752563.89 431...\n",
+       "4           4  POLYGON ((752323.89 4317039.299, 752323.89 431...\n",
+       "5           5  POLYGON ((752403.89 4317039.299, 752403.89 431...\n",
+       "6           6  POLYGON ((752483.89 4317039.299, 752483.89 431...\n",
+       "7           7  POLYGON ((752563.89 4317039.299, 752563.89 431...\n",
+       "8           8  POLYGON ((752323.89 4317119.299, 752323.89 431...\n",
+       "9           9  POLYGON ((752403.89 4317119.299, 752403.89 431...\n",
+       "10         10  POLYGON ((752483.89 4317119.299, 752483.89 431...\n",
+       "11         11  POLYGON ((752563.89 4317119.299, 752563.89 431...\n",
+       "12         12  POLYGON ((752323.89 4317199.299, 752323.89 431...\n",
+       "13         13  POLYGON ((752403.89 4317199.299, 752403.89 431...\n",
+       "14         14  POLYGON ((752483.89 4317199.299, 752483.89 431...\n",
+       "15         15  POLYGON ((752563.89 4317199.299, 752563.89 431..."
       ]
      },
-     "execution_count": 29,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Read and display the bounds layer\n",
-    "gpd.read_file(SAVE_PATH, layer=\"_bounds\")"
+    "gpd.read_file(SAVE_PATH, layer=\"bounds\")"
    ]
   },
   {
@@ -486,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 10,
    "id": "35bfab91",
    "metadata": {},
    "outputs": [],
@@ -496,7 +488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 11,
    "id": "10ed48d3",
    "metadata": {},
    "outputs": [
@@ -506,7 +498,7 @@
        "16"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -517,7 +509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 12,
    "id": "1f87ba05",
    "metadata": {},
    "outputs": [
@@ -537,7 +529,7 @@
        "<Axes: >"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/tree_detection_framework/detection/region_detections.py
+++ b/tree_detection_framework/detection/region_detections.py
@@ -674,8 +674,8 @@ class RegionDetectionsSet:
         """Save to a GPKG file with a single detections layer (all tiles) and a bounds layer.
 
         Layout:
-          - "detections": one layer holding all detections with a "tile_id" column
-          - "bounds": one layer holding all tile bounds with a "tile_id" column
+          - "detections": one layer holding all detections with a "region_ID" column
+          - "bounds": one layer holding all tile bounds with a "region_ID" column
 
         This preserves tile structure (including empty tiles).
         Use from_tiled_file to reconstruct the RegionDetectionsSet exactly.

--- a/tree_detection_framework/detection/region_detections.py
+++ b/tree_detection_framework/detection/region_detections.py
@@ -2,7 +2,6 @@ import copy
 from pathlib import Path
 from typing import Callable, List, Optional, Union
 
-import fiona
 import geopandas as gpd
 import matplotlib.pyplot as plt
 import numpy as np
@@ -672,11 +671,11 @@ class RegionDetectionsSet:
         concatenated_geodataframes.to_file(save_path)
 
     def save_tiled(self, save_path: PATH_TYPE, CRS: Optional[pyproj.CRS] = None):
-        """Save to a GPKG file with one layer per tile plus a single shared bounds layer.
+        """Save to a GPKG file with a single detections layer (all tiles) and a bounds layer.
 
         Layout:
-          - "detections_0", "detections_1", ... one detection layer per tile
-          - "_bounds": one layer holding all tile bounds with a "tile_id" column
+          - "detections": one layer holding all detections with a "tile_id" column
+          - "bounds": one layer holding all tile bounds with a "tile_id" column
 
         This preserves tile structure (including empty tiles).
         Use from_tiled_file to reconstruct the RegionDetectionsSet exactly.
@@ -690,29 +689,41 @@ class RegionDetectionsSet:
         save_path = Path(save_path)
         save_path.parent.mkdir(exist_ok=True, parents=True)
 
+        detection_frames = []
         bounds_records = []
-        first_write = True
+        detections_crs = CRS  # inferred from first non-empty tile if not provided
+
         for i, rd in enumerate(self.region_detections):
             detections = rd.get_data_frame(CRS=CRS)
-            # For empty tiles, skip saving the detections and only save the tile bounds.
-            # They are reconstructed as empty RegionDetections on load via the _bounds layer.
+            if detections_crs is None and len(detections) > 0:
+                detections_crs = detections.crs
             if len(detections) > 0:
-                mode = (
-                    "w" if first_write else "a"
-                )  # "a" appends a new named layer to the existing file
-                detections.to_file(
-                    save_path, layer=f"detections_{i}", driver="GPKG", mode=mode
-                )
-                first_write = False
+                detections = detections.copy()
+                detections["region_ID"] = i  # tag each row with its tile index
+                detection_frames.append(detections)
+            # always record bounds, even for empty tiles
             bounds_geom = rd.get_bounds(CRS=CRS).iloc[0]
-            bounds_records.append({"tile_id": i, "geometry": bounds_geom})
+            bounds_records.append({"region_ID": i, "geometry": bounds_geom})
+
+        # Concatenate all tiles into one layer; write an empty frame if there are no detections
+        if detection_frames:
+            all_detections = gpd.GeoDataFrame(
+                pd.concat(detection_frames, ignore_index=True), crs=detections_crs
+            )
+        else:
+            all_detections = gpd.GeoDataFrame(
+                {"region_ID": pd.Series([], dtype=int)},
+                geometry=gpd.GeoSeries([], crs=detections_crs),
+                crs=detections_crs,
+            )
+        all_detections.to_file(save_path, layer="detections", driver="GPKG", mode="w")
 
         # Collect all bounds into a single layer
         bounds_crs = (
             CRS if CRS is not None else self.get_default_CRS(check_all_have_CRS=False)
         )
         bounds_gdf = gpd.GeoDataFrame(bounds_records, crs=bounds_crs)
-        bounds_gdf.to_file(save_path, layer="_bounds", driver="GPKG", mode="a")
+        bounds_gdf.to_file(save_path, layer="bounds", driver="GPKG", mode="a")
 
     @classmethod
     def from_tiled_file(cls, save_path: PATH_TYPE) -> "RegionDetectionsSet":
@@ -724,44 +735,45 @@ class RegionDetectionsSet:
         Returns:
             RegionDetectionsSet: The reconstructed set with one RegionDetections per tile.
         """
-
         save_path = Path(save_path)
-        layers = fiona.listlayers(str(save_path))
-        detection_layers = sorted(
-            [l for l in layers if l.startswith("detections_")],
-            key=lambda l: int(l.split("_")[1]),
-        )
 
-        # Load the shared bounds layer indexed by tile_id
-        bounds_gdf = gpd.read_file(save_path, layer="_bounds").set_index("tile_id")
+        bounds_gdf = gpd.read_file(save_path, layer="bounds").set_index("region_ID")
         n_tiles = len(bounds_gdf)
+        crs = bounds_gdf.crs
 
-        # Map tile_id -> detection layer name for tiles that have detections
-        detection_layer_map = {int(l.split("_")[1]): l for l in detection_layers}
+        # Split the flat detections layer back into per-tile groups
+        # drop region_ID since it's storage metadata
+        all_detections = gpd.read_file(save_path, layer="detections")
+        if len(all_detections) > 0:
+            crs = all_detections.crs
+            detections_by_tile = {
+                region_id: group.drop(columns=["region_ID"]).reset_index(drop=True)
+                for region_id, group in all_detections.groupby("region_ID")
+            }
+        else:
+            detections_by_tile = {}
 
         region_detections = []
         for i in range(n_tiles):
-            bounds_geom = (
-                bounds_gdf.loc[i, "geometry"] if i in bounds_gdf.index else None
-            )
-            crs = bounds_gdf.crs
+            bounds_geom = bounds_gdf.loc[i, "geometry"] if i in bounds_gdf.index else None
 
-            if i in detection_layer_map:
-                detections = gpd.read_file(save_path, layer=detection_layer_map[i])
-                crs = detections.crs
+            # Get the detections for this tile if they exist
+            if i in detections_by_tile:
+                tile_detections = detections_by_tile[i]
             else:
-                # Empty tile doesn't have a "detections_{i}" layer
-                # Reconstruct it with an empty GeoDataFrame
-                detections = gpd.GeoDataFrame(geometry=gpd.GeoSeries([], crs=crs))
+                # tile was empty - reconstruct with an empty GeoDataFrame
+                tile_detections = gpd.GeoDataFrame(geometry=gpd.GeoSeries([], crs=crs))
 
+            # Create a RegionDetections object for this tile
             rd = RegionDetections(
                 detection_geometries="geometry",
-                data=detections,
+                data=tile_detections,
                 CRS=crs,
                 geospatial_prediction_bounds=bounds_geom,
             )
             region_detections.append(rd)
 
+        # Create and return the RegionDetectionsSet
         return cls(region_detections)
 
     def plot(

--- a/tree_detection_framework/detection/region_detections.py
+++ b/tree_detection_framework/detection/region_detections.py
@@ -754,7 +754,9 @@ class RegionDetectionsSet:
 
         region_detections = []
         for i in range(n_tiles):
-            bounds_geom = bounds_gdf.loc[i, "geometry"] if i in bounds_gdf.index else None
+            bounds_geom = (
+                bounds_gdf.loc[i, "geometry"] if i in bounds_gdf.index else None
+            )
 
             # Get the detections for this tile if they exist
             if i in detections_by_tile:

--- a/tree_detection_framework/detection/region_detections.py
+++ b/tree_detection_framework/detection/region_detections.py
@@ -698,7 +698,6 @@ class RegionDetectionsSet:
             if detections_crs is None and len(detections) > 0:
                 detections_crs = detections.crs
             if len(detections) > 0:
-                detections = detections.copy()
                 detections["region_ID"] = i  # tag each row with its tile index
                 detection_frames.append(detections)
             # always record bounds, even for empty tiles


### PR DESCRIPTION
Updated the `save_tiled` and `from_tiled_file` methods to support handling detections from all regions in the same layer. Previously it was creating a new layer for each region's detections.