### PR TITLE
Include 2 additional geometric detector parameters

### DIFF
--- a/tree_detection_framework/entrypoints/detect_trees.py
+++ b/tree_detection_framework/entrypoints/detect_trees.py
@@ -42,8 +42,16 @@ def detect_trees(
             chip_size=int(detection_params.get("chip_size", CHIP_SIZE)),
             chip_stride=int(detection_params.get("chip_stride", CHIP_STRIDE)),
             resolution=float(detection_params.get("resolution", RESOLUTION)),
-            raster_blur_sigma=float(detection_params["raster_blur_sigma"]) if detection_params.get("raster_blur_sigma") else None,
-            edge_suppression_meters=float(detection_params["edge_suppression_meters"]) if detection_params.get("edge_suppression_meters") else None,
+            raster_blur_sigma=(
+                float(detection_params["raster_blur_sigma"])
+                if detection_params.get("raster_blur_sigma")
+                else None
+            ),
+            edge_suppression_meters=(
+                float(detection_params["edge_suppression_meters"])
+                if detection_params.get("edge_suppression_meters")
+                else None
+            ),
         )
 
     else:

--- a/tree_detection_framework/entrypoints/detect_trees.py
+++ b/tree_detection_framework/entrypoints/detect_trees.py
@@ -43,7 +43,9 @@ def detect_trees(
             chip_stride=int(detection_params.get("chip_stride", CHIP_STRIDE)),
             resolution=float(detection_params.get("resolution", RESOLUTION)),
             raster_blur_sigma=float(detection_params.get("raster_blur_sigma", None)),
-            edge_suppression_meters=float(detection_params.get("edge_suppression_meters", None)),
+            edge_suppression_meters=float(
+                detection_params.get("edge_suppression_meters", None)
+            ),
         )
 
     else:

--- a/tree_detection_framework/entrypoints/detect_trees.py
+++ b/tree_detection_framework/entrypoints/detect_trees.py
@@ -42,6 +42,8 @@ def detect_trees(
             chip_size=int(detection_params.get("chip_size", CHIP_SIZE)),
             chip_stride=int(detection_params.get("chip_stride", CHIP_STRIDE)),
             resolution=float(detection_params.get("resolution", RESOLUTION)),
+            raster_blur_sigma=float(detection_params.get("raster_blur_sigma", None)),
+            edge_suppression_meters=float(detection_params.get("edge_suppression_meters", None)),
         )
 
     else:

--- a/tree_detection_framework/entrypoints/detect_trees.py
+++ b/tree_detection_framework/entrypoints/detect_trees.py
@@ -42,10 +42,8 @@ def detect_trees(
             chip_size=int(detection_params.get("chip_size", CHIP_SIZE)),
             chip_stride=int(detection_params.get("chip_stride", CHIP_STRIDE)),
             resolution=float(detection_params.get("resolution", RESOLUTION)),
-            raster_blur_sigma=float(detection_params.get("raster_blur_sigma", None)),
-            edge_suppression_meters=float(
-                detection_params.get("edge_suppression_meters", None)
-            ),
+            raster_blur_sigma=float(detection_params["raster_blur_sigma"]) if detection_params.get("raster_blur_sigma") else None,
+            edge_suppression_meters=float(detection_params["edge_suppression_meters"]) if detection_params.get("edge_suppression_meters") else None,
         )
 
     else:


### PR DESCRIPTION
It was required to specify `raster_blur_sigma` to do smoothing experiments for the gemetric detector. I also included `edge_suppression_meters` just in case it's needed for other future experiments.